### PR TITLE
Reference playlist expansion + adaptive transcode fix

### DIFF
--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.5.4"
+  version="0.6.5"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/changelog.txt
+++ b/pvr.kofin/changelog.txt
@@ -1,3 +1,30 @@
+v0.6.5
+- Set MinSegments=3 in the Jellyfin device profile when using inputstream.adaptive so the initial variant playlist comes back populated with multiple segments. Adaptive rejects single-segment playlists with "Codec id NN require extradata" even when the master has CODECS attributes; recordings always worked because they came back populated. Adds ~10s of initial buffering for adaptive users; ffmpegdirect stays at MinSegments=1
+
+v0.6.4
+- Fix inputstream.adaptive playback of Jellyfin transcoded/remuxed live TV: keep TS container (not fMP4) and use master.m3u8 — adaptive constructs codec extradata from the master playlist's #EXT-X-STREAM-INF CODECS attribute and demuxes the TS segments cleanly. fMP4 with #EXT-X-MAP confused adaptive's parser; the recording playback path (which always worked with adaptive) was the reference
+
+v0.6.3
+- Fall back to the global InputStream setting when the channel doesn't pin one via M3U, so the device profile container (TS vs fMP4) and URL endpoint (live.m3u8 vs master.m3u8) match the inputstream Kodi actually uses
+- Update InputStream setting help text to warn that inputstream.adaptive doesn't currently work with Jellyfin's live transcode output; recommend FFmpeg Direct for transcoded/remuxed channels
+
+v0.6.2
+- Keep Jellyfin's master.m3u8 path (instead of rewriting to live.m3u8) when the channel uses inputstream.adaptive — adaptive needs the master playlist's #EXT-X-STREAM-INF CODECS attribute to construct codec extradata before opening fMP4 segments
+
+v0.6.1
+- Use fMP4 container in the Jellyfin device profile when the channel uses inputstream.adaptive (newer adaptive can't extract codec extradata from MPEG-TS HLS segments)
+- Trim whitespace on M3U prop values so trailing spaces don't break boolean parsing
+- Read inputstream override from channel properties instead of cached name (was set before KodiProps were applied)
+- Re-declare legacy catchupM3U* settings as hidden so migration reads stop spamming "is not a integer" errors
+
+v0.6.0
+- Reference playlist promoted to first-class M3U layer (channel groups, KodiProps, KofinProps); catchup is now one consumer of it
+- Channel groups from M3U group-title= and #EXTGRP: are added alongside the "Jellyfin" all-channels group
+- KodiProps (#KODIPROP, #EXTVLCOPT, #EXTVLCOPT--) honored: per-channel inputstream selection, mimetype, http-user-agent/referrer/reconnect
+- KofinProps for per-channel device-profile overrides: kofin-force-remux, kofin-bitrate-limit, kofin-force-transcode (e.g. force HDR transcode on a single channel)
+- New global force-transcode codec toggles: AV1, HEVC, MPEG-2, VC-1, VP9 (excludes the codec from direct play / remux)
+- Settings reorganised: Playback split into Transcoding + InputStream; reference-playlist path moved to Advanced. Existing M3U paths migrated automatically.
+
 v0.5.4
 - Fix recording Premiered date for completed recordings (fall back to DateCreated)
 - Set full recording date for skin Premiered info (not just year)

--- a/pvr.kofin/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.kofin/resources/language/resource.language.en_gb/strings.po
@@ -23,9 +23,9 @@ msgctxt "Addon Description"
 msgid "Native Kodi PVR integration for Jellyfin Live TV. Provides live TV channels, EPG, recordings, and timers from a Jellyfin server."
 msgstr ""
 
-#: Playback category
+#: Transcoding category
 msgctxt "#30620"
-msgid "Playback"
+msgid "Transcoding"
 msgstr ""
 
 msgctxt "#30622"
@@ -149,17 +149,17 @@ msgctxt "#30651"
 msgid "Unlimited"
 msgstr ""
 
-#: InputStream
+#: InputStream category
 msgctxt "#30660"
 msgid "InputStream"
 msgstr ""
 
 msgctxt "#30661"
-msgid "InputStream"
+msgid "InputStream addon"
 msgstr ""
 
 msgctxt "#30662"
-msgid "The InputStream addon to use for playback. FFmpeg Direct supports timeshift with a local device buffer. Adaptive supports timeshift with a buffer on the server. FFmpeg (Kodi internal) does not support timeshift."
+msgid "The InputStream addon to use for playback. FFmpeg Direct supports timeshift with a local device buffer. Adaptive supports timeshift with a server-side buffer. FFmpeg (Kodi internal) does not support timeshift."
 msgstr ""
 
 msgctxt "#30663"
@@ -436,4 +436,82 @@ msgstr ""
 
 msgctxt "#30771"
 msgid "Remote path (URL)"
+msgstr ""
+
+#: Reference playlist (advanced category)
+msgctxt "#30772"
+msgid "Reference playlist"
+msgstr ""
+
+msgctxt "#30773"
+msgid "Use reference playlist"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Load a reference M3U playlist that decorates Jellyfin channels with channel groups, KodiProps (inputstream selection, headers), KofinProps (per-channel codec/bitrate overrides) and catchup metadata. Channels are matched by name (case-insensitive)."
+msgstr ""
+
+msgctxt "#30775"
+msgid "Reference playlist location"
+msgstr ""
+
+msgctxt "#30776"
+msgid "Choose whether the reference playlist is stored locally or accessed via a URL."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Reference playlist file"
+msgstr ""
+
+msgctxt "#30778"
+msgid "Path to the reference M3U file on the local filesystem."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Reference playlist URL"
+msgstr ""
+
+msgctxt "#30780"
+msgid "URL of the reference M3U playlist."
+msgstr ""
+
+#: Force-transcode codec toggles
+msgctxt "#30781"
+msgid "Force transcode AV1"
+msgstr ""
+
+msgctxt "#30782"
+msgid "Force the Jellyfin server to transcode AV1 streams. Enable if your device cannot decode AV1."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Force transcode HEVC"
+msgstr ""
+
+msgctxt "#30784"
+msgid "Force the Jellyfin server to transcode HEVC streams. Enable if your device cannot decode HEVC."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Force transcode MPEG-2"
+msgstr ""
+
+msgctxt "#30786"
+msgid "Force the Jellyfin server to transcode MPEG-2 streams. Enable if your device cannot decode MPEG-2."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Force transcode VC-1"
+msgstr ""
+
+msgctxt "#30788"
+msgid "Force the Jellyfin server to transcode VC-1 streams. Enable if your device cannot decode VC-1."
+msgstr ""
+
+msgctxt "#30789"
+msgid "Force transcode VP9"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Force the Jellyfin server to transcode VP9 streams. Enable if your device cannot decode VP9."
 msgstr ""

--- a/pvr.kofin/resources/settings.xml
+++ b/pvr.kofin/resources/settings.xml
@@ -168,13 +168,57 @@
           </constraints>
           <control type="edit" format="string" />
         </setting>
+        <!-- Legacy catchup-M3U keys (kept hidden so InstanceSettings::ReadSettings
+             can migrate values into referencePlaylist*; never shown in UI). -->
+        <setting id="catchupM3UPath" type="string">
+          <level>4</level>
+          <default></default>
+          <constraints><allowempty>true</allowempty></constraints>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="catchupM3UUrl" type="string">
+          <level>4</level>
+          <default></default>
+          <constraints><allowempty>true</allowempty></constraints>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="catchupM3UPathType" type="integer">
+          <level>4</level>
+          <default>0</default>
+          <control type="edit" format="integer" />
+        </setting>
       </group>
     </category>
 
-    <!-- Playback -->
-    <category id="playback" label="30620">
+    <!-- Transcoding -->
+    <category id="transcoding" label="30620">
       <group id="1">
         <setting id="forceTranscode" type="boolean" label="30622" help="30623">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="forceTranscodeAV1" type="boolean" label="30781" help="30782">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="forceTranscodeHEVC" type="boolean" label="30783" help="30784">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="forceTranscodeMPEG2" type="boolean" label="30785" help="30786">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="forceTranscodeVC1" type="boolean" label="30787" help="30788">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="forceTranscodeVP9" type="boolean" label="30789" help="30790">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
@@ -187,6 +231,11 @@
         <setting id="transcodeHevcRext" type="boolean" label="30722" help="30723">
           <level>0</level>
           <default>true</default>
+          <dependencies>
+            <dependency type="enable">
+              <condition operator="is" setting="forceTranscodeHEVC">false</condition>
+            </dependency>
+          </dependencies>
           <control type="toggle" />
         </setting>
         <setting id="preferredVideoCodec" type="integer" label="30624" help="30625">
@@ -240,7 +289,11 @@
           <control type="spinner" format="string" />
         </setting>
       </group>
-      <group id="2" label="30660">
+    </category>
+
+    <!-- InputStream -->
+    <category id="inputstream" label="30660">
+      <group id="1">
         <setting id="inputStream" type="integer" label="30661" help="30662">
           <level>0</level>
           <default>0</default>
@@ -299,53 +352,12 @@
         <setting id="catchupEnabled" type="boolean" label="30731" help="30732">
           <level>0</level>
           <default>false</default>
+          <dependencies>
+            <dependency type="enable">
+              <condition operator="is" setting="referencePlaylistEnabled">true</condition>
+            </dependency>
+          </dependencies>
           <control type="toggle" />
-        </setting>
-        <setting id="catchupM3UPathType" type="integer" label="30733" help="30734">
-          <level>0</level>
-          <default>0</default>
-          <constraints>
-            <options>
-              <option label="30770">0</option>
-              <option label="30771">1</option>
-            </options>
-          </constraints>
-          <dependencies>
-            <dependency type="visible">
-              <condition operator="is" setting="catchupEnabled">true</condition>
-            </dependency>
-          </dependencies>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="catchupM3UPath" type="path" label="30735" help="30736">
-          <level>0</level>
-          <default></default>
-          <constraints>
-            <allowempty>true</allowempty>
-          </constraints>
-          <dependencies>
-            <dependency type="visible">
-              <condition operator="is" setting="catchupEnabled">true</condition>
-              <condition operator="is" setting="catchupM3UPathType">0</condition>
-            </dependency>
-          </dependencies>
-          <control type="button" format="file">
-            <heading>30735</heading>
-          </control>
-        </setting>
-        <setting id="catchupM3UUrl" type="string" label="30737" help="30738">
-          <level>0</level>
-          <default></default>
-          <constraints>
-            <allowempty>true</allowempty>
-          </constraints>
-          <dependencies>
-            <dependency type="visible">
-              <condition operator="is" setting="catchupEnabled">true</condition>
-              <condition operator="is" setting="catchupM3UPathType">1</condition>
-            </dependency>
-          </dependencies>
-          <control type="edit" format="string" />
         </setting>
         <setting id="catchupQueryFormat" type="string" label="30739" help="30740">
           <level>0</level>
@@ -459,6 +471,59 @@
           <level>0</level>
           <default>60</default>
           <control type="edit" format="integer" />
+        </setting>
+      </group>
+      <group id="2" label="30772">
+        <setting id="referencePlaylistEnabled" type="boolean" label="30773" help="30774">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="referencePlaylistPathType" type="integer" label="30775" help="30776">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30770">0</option>
+              <option label="30771">1</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <condition operator="is" setting="referencePlaylistEnabled">true</condition>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="referencePlaylistPath" type="path" label="30777" help="30778">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <condition operator="is" setting="referencePlaylistEnabled">true</condition>
+              <condition operator="is" setting="referencePlaylistPathType">0</condition>
+            </dependency>
+          </dependencies>
+          <control type="button" format="file">
+            <heading>30777</heading>
+          </control>
+        </setting>
+        <setting id="referencePlaylistUrl" type="string" label="30779" help="30780">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <condition operator="is" setting="referencePlaylistEnabled">true</condition>
+              <condition operator="is" setting="referencePlaylistPathType">1</condition>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
         </setting>
       </group>
     </category>

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -464,13 +464,26 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
 {
   if (GetChannel(channel, m_currentChannel))
   {
-    // Resolve live stream URL from Jellyfin via PlaybackInfo
+    // Resolve live stream URL from Jellyfin via PlaybackInfo (with KofinProps overrides).
+    // If the channel didn't pin an inputstream via M3U, fall back to the global
+    // setting so BuildDeviceProfile / PostProcessTranscodingUrl pick the right
+    // container + URL endpoint for the actual inputstream Kodi will use.
+    auto overrides = iptvsimple::jellyfin::ChannelOverrides::FromChannel(m_currentChannel);
+    if (!overrides.inputstream)
+    {
+      switch (m_settings->GetInputStream())
+      {
+        case 0: overrides.inputstream = "inputstream.ffmpegdirect"; break;
+        case 1: overrides.inputstream = "inputstream.adaptive"; break;
+        case 2: overrides.inputstream = "inputstream.ffmpeg"; break;
+      }
+    }
     std::string streamURL;
     if (m_channelLoader)
     {
       const std::string& jellyfinId = m_channelLoader->GetJellyfinId(m_currentChannel.GetUniqueId());
       if (!jellyfinId.empty())
-        streamURL = m_channelLoader->GetLiveStreamUrl(jellyfinId);
+        streamURL = m_channelLoader->GetLiveStreamUrl(jellyfinId, overrides);
     }
 
     if (streamURL.empty())
@@ -486,6 +499,12 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
     properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamURL);
     properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, "application/vnd.apple.mpegurl");
 
+    // Honor an inputstream override set via M3U KodiProps. Read directly
+    // from the property map (not GetInputStreamName(), which is cached when
+    // SetStreamURL() was called — before KodiProps were applied).
+    std::string channelInputstream = m_currentChannel.GetProperty(PVR_STREAM_PROPERTY_INPUTSTREAM);
+    if (channelInputstream.empty())
+      channelInputstream = m_currentChannel.GetProperty("inputstream");
     const int inputStream = m_settings->GetInputStream();
 
     // Catchup: if direct play + ffmpegdirect + channel supports catchup,
@@ -493,7 +512,14 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
     // CatchupController is persistent — if GetEPGTagStreamProperties was called
     // first, it stored the programme times and ProcessChannelForPlayback will
     // use them (same pattern as pvr.iptvsimple).
-    if (isDirectPlay && inputStream == 0 && m_currentChannel.IsCatchupSupported())
+    const bool useFfmpegDirect = !channelInputstream.empty()
+      ? channelInputstream == "inputstream.ffmpegdirect"
+      : inputStream == 0;
+    const bool useAdaptive = !channelInputstream.empty()
+      ? channelInputstream == "inputstream.adaptive"
+      : inputStream == 1;
+
+    if (isDirectPlay && useFfmpegDirect && m_currentChannel.IsCatchupSupported())
     {
       // Update channel's stream URL to the actual tuner URL
       m_currentChannel.SetStreamURL(streamURL);
@@ -532,7 +558,7 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
                   WebUtils::RedactUrl(streamURL).c_str(),
                   m_currentChannel.GetCatchupDays());
     }
-    else if (inputStream == 0) // FFmpegDirect without catchup
+    else if (useFfmpegDirect)
     {
       properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.ffmpegdirect");
       properties.emplace_back("inputstream.ffmpegdirect.manifest_type", "hls");
@@ -540,12 +566,31 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
       if (m_settings->GetTimeshiftEnabled())
         properties.emplace_back("inputstream.ffmpegdirect.stream_mode", "timeshift");
     }
-    else if (inputStream == 1) // Adaptive
+    else if (useAdaptive)
     {
       properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.adaptive");
       properties.emplace_back("inputstream.adaptive.manifest_type", "hls");
     }
-    // inputStream == 2: Kodi internal — no inputstream addon
+    else if (!channelInputstream.empty())
+    {
+      // Channel pinned a non-ffmpegdirect/adaptive inputstream (e.g. internal)
+      properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, channelInputstream);
+    }
+    // else inputStream == 2: Kodi internal — no inputstream addon
+
+    // Forward channel-level KodiProps from the M3U (inputstream.*, mimetype,
+    // http-* etc.). Skip kofin-* (consumed by ChannelOverrides) and skip the
+    // inputstream key itself (already set above). M3U props win over our
+    // defaults via emplace order — Kodi keeps the last value for a given key.
+    for (const auto& kv : m_currentChannel.GetProperties())
+    {
+      const std::string& key = kv.first;
+      if (key.rfind("kofin-", 0) == 0)
+        continue;
+      if (key == PVR_STREAM_PROPERTY_INPUTSTREAM || key == "inputstream")
+        continue;
+      properties.emplace_back(key, kv.second);
+    }
 
     Logger::Log(LogLevel::LEVEL_INFO, "%s - Stream URL: %s", __FUNCTION__, WebUtils::RedactUrl(streamURL).c_str());
 
@@ -681,13 +726,24 @@ PVR_ERROR IptvSimple::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& ta
   if (!GetChannel(tag.GetUniqueChannelId(), channel) || !channel.IsCatchupSupported())
     return PVR_ERROR_FAILED;
 
-  // Resolve the direct play URL for this channel
+  // Resolve the direct play URL for this channel (with KofinProps overrides).
+  // Same global-inputstream fallback as the live channel path.
+  auto epgOverrides = iptvsimple::jellyfin::ChannelOverrides::FromChannel(channel);
+  if (!epgOverrides.inputstream)
+  {
+    switch (m_settings->GetInputStream())
+    {
+      case 0: epgOverrides.inputstream = "inputstream.ffmpegdirect"; break;
+      case 1: epgOverrides.inputstream = "inputstream.adaptive"; break;
+      case 2: epgOverrides.inputstream = "inputstream.ffmpeg"; break;
+    }
+  }
   std::string streamURL;
   if (m_channelLoader)
   {
     const std::string& jellyfinId = m_channelLoader->GetJellyfinId(channel.GetUniqueId());
     if (!jellyfinId.empty())
-      streamURL = m_channelLoader->GetLiveStreamUrl(jellyfinId);
+      streamURL = m_channelLoader->GetLiveStreamUrl(jellyfinId, epgOverrides);
   }
 
   if (streamURL.empty())

--- a/src/iptvsimple/InstanceSettings.cpp
+++ b/src/iptvsimple/InstanceSettings.cpp
@@ -65,6 +65,11 @@ void InstanceSettings::ReadSettings()
   m_forceTranscode = kodi::addon::GetSettingBoolean("forceTranscode", false);
   m_transcodeHi10P = kodi::addon::GetSettingBoolean("transcodeHi10P", true);
   m_transcodeHevcRext = kodi::addon::GetSettingBoolean("transcodeHevcRext", true);
+  m_forceTranscodeAV1 = kodi::addon::GetSettingBoolean("forceTranscodeAV1", false);
+  m_forceTranscodeHEVC = kodi::addon::GetSettingBoolean("forceTranscodeHEVC", false);
+  m_forceTranscodeMPEG2 = kodi::addon::GetSettingBoolean("forceTranscodeMPEG2", false);
+  m_forceTranscodeVC1 = kodi::addon::GetSettingBoolean("forceTranscodeVC1", false);
+  m_forceTranscodeVP9 = kodi::addon::GetSettingBoolean("forceTranscodeVP9", false);
   m_preferredVideoCodec = kodi::addon::GetSettingInt("preferredVideoCodec", 0);
   m_preferredAudioCodec = kodi::addon::GetSettingInt("preferredAudioCodec", 0);
   m_maxStreamingBitrate = kodi::addon::GetSettingInt("maxStreamingBitrate", 15);
@@ -74,15 +79,37 @@ void InstanceSettings::ReadSettings()
   m_timeshiftEnabled = kodi::addon::GetSettingBoolean("timeshiftEnabled", true);
   m_inProgressInputStream = kodi::addon::GetSettingInt("inProgressInputStream", 0);
 
+  // Reference playlist (with one-shot migration from legacy catchupM3U* keys)
+  {
+    const std::string newPathLocal = kodi::addon::GetSettingString("referencePlaylistPath", "");
+    const std::string newPathUrl = kodi::addon::GetSettingString("referencePlaylistUrl", "");
+    const int newPathType = kodi::addon::GetSettingInt("referencePlaylistPathType", -1);
+
+    const std::string legacyPathLocal = kodi::addon::GetSettingString("catchupM3UPath", "");
+    const std::string legacyPathUrl = kodi::addon::GetSettingString("catchupM3UUrl", "");
+    const int legacyPathType = kodi::addon::GetSettingInt("catchupM3UPathType", 0);
+
+    if (newPathType < 0 && (!legacyPathLocal.empty() || !legacyPathUrl.empty()))
+    {
+      // Migrate once
+      kodi::addon::SetSettingInt("referencePlaylistPathType", legacyPathType);
+      kodi::addon::SetSettingString("referencePlaylistPath", legacyPathLocal);
+      kodi::addon::SetSettingString("referencePlaylistUrl", legacyPathUrl);
+      m_referencePlaylistPath = (legacyPathType == 0) ? legacyPathLocal : legacyPathUrl;
+      // Default the new master toggle to whatever catchupEnabled was
+      if (kodi::addon::GetSettingBoolean("catchupEnabled", false))
+        kodi::addon::SetSettingBoolean("referencePlaylistEnabled", true);
+    }
+    else
+    {
+      const int pathType = (newPathType >= 0) ? newPathType : 0;
+      m_referencePlaylistPath = (pathType == 0) ? newPathLocal : newPathUrl;
+    }
+  }
+  m_referencePlaylistEnabled = kodi::addon::GetSettingBoolean("referencePlaylistEnabled", false);
+
   // Catchup
   m_catchupEnabled = kodi::addon::GetSettingBoolean("catchupEnabled", false);
-  {
-    int pathType = kodi::addon::GetSettingInt("catchupM3UPathType", 0);
-    if (pathType == 0) // Local file
-      m_catchupM3UPath = kodi::addon::GetSettingString("catchupM3UPath", "");
-    else // Network URL
-      m_catchupM3UPath = kodi::addon::GetSettingString("catchupM3UUrl", "");
-  }
   m_catchupQueryFormat = kodi::addon::GetSettingString("catchupQueryFormat", "");
   m_catchupDays = kodi::addon::GetSettingInt("catchupDays", 5);
   m_allChannelsCatchupMode = kodi::addon::GetSettingInt("allChannelsCatchupMode", 0);

--- a/src/iptvsimple/InstanceSettings.h
+++ b/src/iptvsimple/InstanceSettings.h
@@ -88,6 +88,11 @@ namespace iptvsimple
     bool GetForceTranscode() const { return m_forceTranscode; }
     bool GetTranscodeHi10P() const { return m_transcodeHi10P; }
     bool GetTranscodeHevcRext() const { return m_transcodeHevcRext; }
+    bool GetForceTranscodeAV1() const { return m_forceTranscodeAV1; }
+    bool GetForceTranscodeHEVC() const { return m_forceTranscodeHEVC; }
+    bool GetForceTranscodeMPEG2() const { return m_forceTranscodeMPEG2; }
+    bool GetForceTranscodeVC1() const { return m_forceTranscodeVC1; }
+    bool GetForceTranscodeVP9() const { return m_forceTranscodeVP9; }
     int GetPreferredVideoCodec() const { return m_preferredVideoCodec; }
     int GetPreferredAudioCodec() const { return m_preferredAudioCodec; }
     int GetMaxStreamingBitrateKbps() const
@@ -109,9 +114,12 @@ namespace iptvsimple
     // In-progress recording input stream: 0 = adaptive, 1 = kodi internal
     int GetInProgressInputStream() const { return m_inProgressInputStream; }
 
+    // Reference playlist (master toggle for the M3U layer; catchup also requires this on)
+    bool ReferencePlaylistEnabled() const { return m_referencePlaylistEnabled; }
+    const std::string& GetReferencePlaylistPath() const { return m_referencePlaylistPath; }
+
     // Catchup
-    bool CatchupEnabled() const { return m_catchupEnabled; }
-    const std::string& GetCatchupM3UPath() const { return m_catchupM3UPath; }
+    bool CatchupEnabled() const { return m_catchupEnabled && m_referencePlaylistEnabled; }
     const std::string& GetCatchupQueryFormat() const { return m_catchupQueryFormat; }
     int GetCatchupDays() const { return m_catchupDays; }
     int GetAllChannelsCatchupMode() const { return m_allChannelsCatchupMode; }
@@ -168,6 +176,11 @@ namespace iptvsimple
     bool m_forceTranscode = false;
     bool m_transcodeHi10P = true;
     bool m_transcodeHevcRext = true;
+    bool m_forceTranscodeAV1 = false;
+    bool m_forceTranscodeHEVC = false;
+    bool m_forceTranscodeMPEG2 = false;
+    bool m_forceTranscodeVC1 = false;
+    bool m_forceTranscodeVP9 = false;
     int m_preferredVideoCodec = 0;  // 0=H264, 1=H265, 2=AV1
     int m_preferredAudioCodec = 0;  // 0=AAC, 1=AC3, 2=MP3, 3=Opus
     int m_maxStreamingBitrate = 15; // index into BITRATE_TABLE (15=unlimited)
@@ -177,9 +190,12 @@ namespace iptvsimple
     bool m_timeshiftEnabled = true;
     int m_inProgressInputStream = 0;  // 0=adaptive, 1=kodi internal
 
+    // Reference playlist
+    bool m_referencePlaylistEnabled = false;
+    std::string m_referencePlaylistPath;
+
     // Catchup
     bool m_catchupEnabled = false;
-    std::string m_catchupM3UPath;
     std::string m_catchupQueryFormat;
     int m_catchupDays = 5;
     int m_allChannelsCatchupMode = 0;  // 0=disabled, 3=shift

--- a/src/iptvsimple/M3UParser.cpp
+++ b/src/iptvsimple/M3UParser.cpp
@@ -3,6 +3,10 @@
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.
+ *
+ *  Marker parsing helpers (ReadMarkerValue, ParseSinglePropertyIntoMap)
+ *  are adapted from pvr.iptvsimple PlaylistLoader (GPL-2.0-or-later,
+ *  Copyright (C) 2005-2021 Team Kodi).
  */
 
 #include "M3UParser.h"
@@ -13,24 +17,38 @@
 #include <algorithm>
 #include <cctype>
 #include <fstream>
+#include <set>
 #include <sstream>
 
 #include <kodi/Filesystem.h>
+#include <kodi/addon-instance/PVR.h>
 
 using namespace iptvsimple;
 using namespace iptvsimple::utilities;
 
-// M3U tag markers (same as pvr.iptvsimple PlaylistLoader)
-static const std::string CATCHUP          = "catchup=";
-static const std::string CATCHUP_TYPE     = "catchup-type=";
-static const std::string CATCHUP_DAYS     = "catchup-days=";
-static const std::string CATCHUP_SOURCE   = "catchup-source=";
-static const std::string CATCHUP_SIPTV    = "timeshift=";
-static const std::string CATCHUP_CORRECTION = "catchup-correction=";
-static const std::string TVG_NAME         = "tvg-name=";
-static const std::string EXTINF           = "#EXTINF";
+namespace
+{
 
-static std::string ToLower(const std::string& str)
+// M3U markers
+const std::string EXTM3U                  = "#EXTM3U";
+const std::string EXTINF                  = "#EXTINF";
+const std::string EXTGRP                  = "#EXTGRP:";
+const std::string KODIPROP_MARKER         = "#KODIPROP:";
+const std::string EXTVLCOPT_MARKER        = "#EXTVLCOPT:";
+const std::string EXTVLCOPT_DASH_MARKER   = "#EXTVLCOPT--";
+
+// Per-channel attribute markers
+const std::string TVG_NAME                = "tvg-name=";
+const std::string TVG_LOGO                = "tvg-logo=";
+const std::string GROUP_NAME              = "group-title=";
+const std::string CATCHUP                 = "catchup=";
+const std::string CATCHUP_TYPE            = "catchup-type=";
+const std::string CATCHUP_DAYS            = "catchup-days=";
+const std::string CATCHUP_SOURCE          = "catchup-source=";
+const std::string CATCHUP_SIPTV           = "timeshift=";
+const std::string CATCHUP_CORRECTION      = "catchup-correction=";
+
+std::string ToLower(const std::string& str)
 {
   std::string lower = str;
   std::transform(lower.begin(), lower.end(), lower.begin(),
@@ -38,199 +56,368 @@ static std::string ToLower(const std::string& str)
   return lower;
 }
 
-M3UParser::M3UParser(std::shared_ptr<InstanceSettings>& settings)
-  : m_settings(settings) {}
-
-bool M3UParser::Parse()
+void TrimInPlace(std::string& s)
 {
-  m_catchupMap.clear();
-
-  const std::string& path = m_settings->GetCatchupM3UPath();
-  if (path.empty())
-    return false;
-
-  // Read the file — supports local paths and HTTP/HTTPS URLs via Kodi VFS
-  std::string content;
-
-  if (path.find("://") != std::string::npos)
-  {
-    // Network file — use kodi::vfs::CFile
-    kodi::vfs::CFile file;
-    if (!file.OpenFile(path, 0))
-    {
-      Logger::Log(LEVEL_ERROR, "%s - Failed to open M3U URL: %s", __FUNCTION__, path.c_str());
-      return false;
-    }
-
-    char buffer[4096];
-    ssize_t bytesRead;
-    while ((bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
-      content.append(buffer, static_cast<size_t>(bytesRead));
-    file.Close();
-  }
+  size_t start = s.find_first_not_of(" \t");
+  size_t end = s.find_last_not_of(" \t\r\n");
+  if (start == std::string::npos)
+    s.clear();
   else
-  {
-    // Local file
-    std::ifstream file(path);
-    if (!file.is_open())
-    {
-      Logger::Log(LEVEL_ERROR, "%s - Failed to open M3U file: %s", __FUNCTION__, path.c_str());
-      return false;
-    }
-    std::ostringstream ss;
-    ss << file.rdbuf();
-    content = ss.str();
-  }
-
-  // Parse line by line
-  std::istringstream stream(content);
-  std::string line;
-  const int defaultCatchupMode = m_settings->GetAllChannelsCatchupMode();
-  const int defaultCatchupDays = m_settings->GetCatchupDays();
-
-  while (std::getline(stream, line))
-  {
-    // Trim \r
-    if (!line.empty() && line.back() == '\r')
-      line.pop_back();
-
-    if (line.find(EXTINF) != 0)
-      continue;
-
-    // Extract channel name — everything after the last comma, trimmed
-    std::string channelName;
-    auto lastComma = line.rfind(',');
-    if (lastComma != std::string::npos)
-    {
-      channelName = line.substr(lastComma + 1);
-      // Trim leading/trailing whitespace
-      size_t start = channelName.find_first_not_of(" \t");
-      size_t end = channelName.find_last_not_of(" \t");
-      if (start != std::string::npos)
-        channelName = channelName.substr(start, end - start + 1);
-      else
-        channelName.clear();
-    }
-
-    // Also try tvg-name as alternative
-    std::string tvgName = ReadMarkerValue(line, TVG_NAME);
-
-    if (channelName.empty() && tvgName.empty())
-      continue;
-
-    // Parse catchup tags
-    std::string strCatchup = ReadMarkerValue(line, CATCHUP);
-    if (strCatchup.empty())
-      strCatchup = ReadMarkerValue(line, CATCHUP_TYPE);
-    std::string strCatchupDays = ReadMarkerValue(line, CATCHUP_DAYS);
-    std::string strCatchupSource = ReadMarkerValue(line, CATCHUP_SOURCE);
-    std::string strCatchupSiptv = ReadMarkerValue(line, CATCHUP_SIPTV);
-    std::string strCatchupCorrection = ReadMarkerValue(line, CATCHUP_CORRECTION);
-
-    M3UCatchupInfo info;
-
-    // Determine catchup mode
-    if (!strCatchup.empty())
-    {
-      info.mode = ParseCatchupMode(strCatchup);
-      info.hasCatchup = (info.mode != CatchupMode::DISABLED);
-    }
-    else if (!strCatchupSiptv.empty() && std::atoi(strCatchupSiptv.c_str()) > 0)
-    {
-      // timeshift= is legacy SIPTV format → SHIFT mode (only if days > 0)
-      info.mode = CatchupMode::SHIFT;
-      info.hasCatchup = true;
-      if (strCatchupDays.empty())
-        strCatchupDays = strCatchupSiptv;
-    }
-    else if (defaultCatchupMode > 0)
-    {
-      info.mode = static_cast<CatchupMode>(defaultCatchupMode);
-      info.hasCatchup = true;
-    }
-
-    if (!info.hasCatchup)
-      continue;
-
-    // Catchup days
-    if (!strCatchupDays.empty())
-      info.days = std::atoi(strCatchupDays.c_str());
-    else
-      info.days = defaultCatchupDays;
-
-    // Catchup source
-    info.source = strCatchupSource;
-
-    // Correction (in hours, converted to float)
-    if (!strCatchupCorrection.empty())
-      info.correctionHours = static_cast<float>(std::atof(strCatchupCorrection.c_str()));
-
-    // Store by both channel name and tvg-name (case-insensitive)
-    if (!channelName.empty())
-      m_catchupMap[ToLower(channelName)] = info;
-    if (!tvgName.empty() && ToLower(tvgName) != ToLower(channelName))
-      m_catchupMap[ToLower(tvgName)] = info;
-
-    Logger::Log(LEVEL_DEBUG, "%s - Catchup channel '%s': mode=%d, days=%d, source='%s'",
-                __FUNCTION__, channelName.c_str(), static_cast<int>(info.mode),
-                info.days, info.source.c_str());
-  }
-
-  Logger::Log(LEVEL_INFO, "%s - Parsed %d catchup channels from reference M3U",
-              __FUNCTION__, static_cast<int>(m_catchupMap.size()));
-  return !m_catchupMap.empty();
+    s = s.substr(start, end - start + 1);
 }
 
-const M3UCatchupInfo* M3UParser::GetCatchupInfo(const std::string& channelName) const
-{
-  auto it = m_catchupMap.find(ToLower(channelName));
-  if (it != m_catchupMap.end())
-    return &it->second;
-  return nullptr;
-}
-
-std::string M3UParser::ReadMarkerValue(const std::string& line, const std::string& marker) const
+// Adapted from pvr.iptvsimple PlaylistLoader::ReadMarkerValue.
+// For group-title= the value is everything to end-of-line (semicolons are
+// the in-value separator); for everything else we stop at space or quote.
+std::string ReadMarkerValue(const std::string& line, const std::string& marker)
 {
   size_t pos = line.find(marker);
   if (pos == std::string::npos)
     return "";
 
   pos += marker.length();
+  if (pos >= line.length())
+    return "";
 
-  // Value may be quoted or unquoted
-  if (pos < line.length() && line[pos] == '"')
+  if (marker == GROUP_NAME && line[pos] != '"')
+    return line.substr(pos);
+
+  char terminator = ' ';
+  if (line[pos] == '"')
   {
-    // Quoted value
+    terminator = '"';
     pos++;
-    size_t end = line.find('"', pos);
-    if (end != std::string::npos)
-      return line.substr(pos, end - pos);
-    return line.substr(pos);
   }
-  else
-  {
-    // Unquoted — read until next space or end
-    size_t end = line.find(' ', pos);
-    if (end != std::string::npos)
-      return line.substr(pos, end - pos);
-    // Could also end at comma
-    end = line.rfind(',');
-    if (end != std::string::npos && end > pos)
-      return line.substr(pos, end - pos);
-    return line.substr(pos);
-  }
+  size_t end = line.find(terminator, pos);
+  if (end == std::string::npos)
+    end = line.length();
+  return line.substr(pos, end - pos);
 }
 
-CatchupMode M3UParser::ParseCatchupMode(const std::string& modeStr) const
+CatchupMode ParseCatchupMode(const std::string& modeStr)
 {
   std::string mode = ToLower(modeStr);
   if (mode == "default")       return CatchupMode::DEFAULT;
   if (mode == "append")        return CatchupMode::APPEND;
   if (mode == "shift")         return CatchupMode::SHIFT;
-  if (mode == "flussonic" || mode == "flussonic-ts" || mode == "fs")
+  if (mode == "flussonic" || mode == "flussonic-hls" ||
+      mode == "flussonic-ts" || mode == "fs")
                                return CatchupMode::FLUSSONIC;
   if (mode == "xc")            return CatchupMode::XTREAM_CODES;
   if (mode == "timeshift")     return CatchupMode::TIMESHIFT;
   if (mode == "vod")           return CatchupMode::VOD;
   return CatchupMode::DISABLED;
+}
+
+// Adapted from pvr.iptvsimple PlaylistLoader::ParseSinglePropertyIntoChannel.
+// Writes filtered key/value into either kodiProps or kofinProps depending on
+// the marker and the key. Returns false if the property is rejected.
+void ParseSinglePropertyIntoMap(const std::string& line,
+                                const std::string& marker,
+                                M3UChannelInfo& info)
+{
+  // For #KODIPROP: and #WEBPROP: the value can contain spaces, so the marker
+  // grabs everything to end-of-line.
+  std::string value;
+  if (marker == KODIPROP_MARKER)
+  {
+    auto pos = line.find(marker);
+    if (pos == std::string::npos)
+      return;
+    value = line.substr(pos + marker.length());
+  }
+  else
+  {
+    value = ReadMarkerValue(line, marker);
+  }
+
+  auto eq = value.find('=');
+  if (eq == std::string::npos)
+    return;
+
+  std::string prop = value.substr(0, eq);
+  std::string propValue = value.substr(eq + 1);
+  // Trim leading/trailing whitespace (including CR) so values like
+  // `kofin-force-remux=true ` (trailing space) parse correctly.
+  TrimInPlace(prop);
+  TrimInPlace(propValue);
+  std::transform(prop.begin(), prop.end(), prop.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  if (marker == EXTVLCOPT_DASH_MARKER)
+  {
+    // Whitelist — only http-reconnect
+    if (prop != "http-reconnect")
+      return;
+    info.kodiProps[prop] = propValue;
+    return;
+  }
+  if (marker == EXTVLCOPT_MARKER)
+  {
+    // Whitelist — http-user-agent / http-referrer / program
+    if (prop != "http-user-agent" && prop != "http-referrer" && prop != "program")
+      return;
+    info.kodiProps[prop] = propValue;
+    return;
+  }
+
+  // KODIPROP_MARKER from here on
+  if (prop == "inputstreamaddon" || prop == "inputstreamclass")
+    prop = PVR_STREAM_PROPERTY_INPUTSTREAM;
+
+  // KofinProps — never forwarded to Kodi
+  if (prop.rfind("kofin-", 0) == 0)
+  {
+    info.kofinProps[prop] = propValue;
+    return;
+  }
+
+  // For pvr.kofin we only want inputstream-related KodiProps; Jellyfin
+  // already supplies the stream URL and most other knobs.
+  if (prop == "inputstream" ||
+      prop == PVR_STREAM_PROPERTY_INPUTSTREAM ||
+      prop == PVR_STREAM_PROPERTY_MIMETYPE ||
+      prop.rfind("inputstream.", 0) == 0)
+  {
+    info.kodiProps[prop] = propValue;
+  }
+}
+
+// Split a semicolon list and append unique entries to dest, also tracking
+// global ordering.
+void SplitGroupNames(const std::string& list,
+                     std::vector<std::string>& dest,
+                     std::vector<std::string>& allGroups,
+                     std::set<std::string>& allGroupSet)
+{
+  std::stringstream ss(list);
+  std::string name;
+  while (std::getline(ss, name, ';'))
+  {
+    TrimInPlace(name);
+    if (name.empty())
+      continue;
+    if (std::find(dest.begin(), dest.end(), name) == dest.end())
+      dest.push_back(name);
+    if (allGroupSet.insert(name).second)
+      allGroups.push_back(name);
+  }
+}
+
+bool LoadFileContents(const std::string& path, std::string& out)
+{
+  if (path.find("://") != std::string::npos)
+  {
+    kodi::vfs::CFile file;
+    if (!file.OpenFile(path, 0))
+      return false;
+    char buffer[4096];
+    ssize_t bytesRead;
+    while ((bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
+      out.append(buffer, static_cast<size_t>(bytesRead));
+    file.Close();
+    return true;
+  }
+
+  std::ifstream file(path);
+  if (!file.is_open())
+    return false;
+  std::ostringstream ss;
+  ss << file.rdbuf();
+  out = ss.str();
+  return true;
+}
+
+} // anonymous namespace
+
+M3UParser::M3UParser(std::shared_ptr<InstanceSettings>& settings)
+  : m_settings(settings) {}
+
+bool M3UParser::Parse()
+{
+  m_channels.clear();
+  m_allGroupNames.clear();
+
+  const std::string& path = m_settings->GetReferencePlaylistPath();
+  if (path.empty())
+    return false;
+
+  std::string content;
+  if (!LoadFileContents(path, content))
+  {
+    Logger::Log(LEVEL_ERROR, "%s - Failed to open reference playlist: %s",
+                __FUNCTION__, path.c_str());
+    return false;
+  }
+
+  std::set<std::string> allGroupSet;
+
+  // #EXTGRP: is a begin directive that applies to subsequent entries until
+  // a per-entry group-title= overrides or another #EXTGRP: appears.
+  std::vector<std::string> currentExtGrpNames;
+
+  // Per-entry pending state — applied when the URL line is seen.
+  M3UChannelInfo pending;
+  std::string pendingChannelName;
+  bool pendingHasEntry = false;
+  bool pendingGroupsFromBeginDirective = false;
+
+  const int defaultCatchupMode = m_settings->GetAllChannelsCatchupMode();
+  const int defaultCatchupDays = m_settings->GetCatchupDays();
+
+  std::istringstream stream(content);
+  std::string line;
+  while (std::getline(stream, line))
+  {
+    if (!line.empty() && line.back() == '\r')
+      line.pop_back();
+
+    if (line.empty())
+      continue;
+
+    if (line.rfind(EXTINF, 0) == 0)
+    {
+      // Start a new entry. Apply pending if URL was missing (defensive).
+      pending = M3UChannelInfo{};
+      pendingChannelName.clear();
+      pendingHasEntry = true;
+      pendingGroupsFromBeginDirective = false;
+
+      // Channel name = text after the last comma.
+      auto lastComma = line.rfind(',');
+      if (lastComma != std::string::npos)
+      {
+        pendingChannelName = line.substr(lastComma + 1);
+        TrimInPlace(pendingChannelName);
+      }
+
+      // tvg-name fallback if comma name is empty
+      std::string tvgName = ReadMarkerValue(line, TVG_NAME);
+      if (pendingChannelName.empty())
+        pendingChannelName = tvgName;
+
+      // tvg-logo override
+      pending.tvgLogo = ReadMarkerValue(line, TVG_LOGO);
+
+      // group-title= (per-entry; takes priority over #EXTGRP)
+      const std::string groupList = ReadMarkerValue(line, GROUP_NAME);
+      if (!groupList.empty())
+      {
+        SplitGroupNames(groupList, pending.groupNames, m_allGroupNames, allGroupSet);
+      }
+      else if (!currentExtGrpNames.empty())
+      {
+        pending.groupNames = currentExtGrpNames;
+        pendingGroupsFromBeginDirective = true;
+      }
+
+      // Catchup attributes
+      std::string strCatchup = ReadMarkerValue(line, CATCHUP);
+      if (strCatchup.empty())
+        strCatchup = ReadMarkerValue(line, CATCHUP_TYPE);
+      const std::string strCatchupDays = ReadMarkerValue(line, CATCHUP_DAYS);
+      const std::string strCatchupSource = ReadMarkerValue(line, CATCHUP_SOURCE);
+      const std::string strCatchupSiptv = ReadMarkerValue(line, CATCHUP_SIPTV);
+      const std::string strCatchupCorrection = ReadMarkerValue(line, CATCHUP_CORRECTION);
+
+      if (!strCatchup.empty())
+      {
+        pending.catchupMode = ParseCatchupMode(strCatchup);
+        pending.hasCatchup = (pending.catchupMode != CatchupMode::DISABLED);
+      }
+      else if (!strCatchupSiptv.empty() && std::atoi(strCatchupSiptv.c_str()) > 0)
+      {
+        pending.catchupMode = CatchupMode::SHIFT;
+        pending.hasCatchup = true;
+      }
+      else if (defaultCatchupMode > 0)
+      {
+        pending.catchupMode = static_cast<CatchupMode>(defaultCatchupMode);
+        pending.hasCatchup = true;
+      }
+
+      if (!strCatchupDays.empty())
+        pending.catchupDays = std::atoi(strCatchupDays.c_str());
+      else if (!strCatchupSiptv.empty())
+        pending.catchupDays = std::atoi(strCatchupSiptv.c_str());
+      else
+        pending.catchupDays = defaultCatchupDays;
+
+      pending.catchupSource = strCatchupSource;
+      if (!strCatchupCorrection.empty())
+        pending.catchupCorrectionHours = static_cast<float>(std::atof(strCatchupCorrection.c_str()));
+
+      continue;
+    }
+
+    if (line.rfind(KODIPROP_MARKER, 0) == 0 && pendingHasEntry)
+    {
+      ParseSinglePropertyIntoMap(line, KODIPROP_MARKER, pending);
+      continue;
+    }
+    if (line.rfind(EXTVLCOPT_DASH_MARKER, 0) == 0 && pendingHasEntry)
+    {
+      ParseSinglePropertyIntoMap(line, EXTVLCOPT_DASH_MARKER, pending);
+      continue;
+    }
+    if (line.rfind(EXTVLCOPT_MARKER, 0) == 0 && pendingHasEntry)
+    {
+      ParseSinglePropertyIntoMap(line, EXTVLCOPT_MARKER, pending);
+      continue;
+    }
+
+    if (line.rfind(EXTGRP, 0) == 0)
+    {
+      currentExtGrpNames.clear();
+      const std::string list = ReadMarkerValue(line, EXTGRP);
+      if (!list.empty())
+        SplitGroupNames(list, currentExtGrpNames, m_allGroupNames, allGroupSet);
+      // If a pending entry has no per-entry groups yet, adopt the new
+      // begin-directive list.
+      if (pendingHasEntry && pending.groupNames.empty())
+      {
+        pending.groupNames = currentExtGrpNames;
+        pendingGroupsFromBeginDirective = true;
+      }
+      continue;
+    }
+
+    if (line[0] == '#' || line[0] == '\0')
+      continue;
+
+    // URL line — finalize pending entry.
+    if (pendingHasEntry && !pendingChannelName.empty())
+    {
+      // Persist by lowercase channel name. If duplicate, last one wins.
+      m_channels[ToLower(pendingChannelName)] = pending;
+
+      Logger::Log(LEVEL_DEBUG,
+                  "%s - Parsed '%s': groups=%zu kodiProps=%zu kofinProps=%zu catchup=%s",
+                  __FUNCTION__, pendingChannelName.c_str(),
+                  pending.groupNames.size(), pending.kodiProps.size(),
+                  pending.kofinProps.size(),
+                  pending.hasCatchup ? "yes" : "no");
+    }
+
+    // Reset pending; clear group adoption flag so next entry without groups
+    // picks up the current #EXTGRP directive again.
+    pendingHasEntry = false;
+    pendingChannelName.clear();
+    pending = M3UChannelInfo{};
+    if (!pendingGroupsFromBeginDirective)
+      pendingGroupsFromBeginDirective = false; // explicit reset
+  }
+
+  Logger::Log(LEVEL_INFO,
+              "%s - Parsed %zu entries, %zu unique groups from reference playlist",
+              __FUNCTION__, m_channels.size(), m_allGroupNames.size());
+  return !m_channels.empty();
+}
+
+const M3UChannelInfo* M3UParser::GetChannelInfo(const std::string& channelName) const
+{
+  auto it = m_channels.find(ToLower(channelName));
+  if (it != m_channels.end())
+    return &it->second;
+  return nullptr;
 }

--- a/src/iptvsimple/M3UParser.h
+++ b/src/iptvsimple/M3UParser.h
@@ -12,21 +12,37 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace iptvsimple
 {
 
 class InstanceSettings;
 
-// Catchup metadata extracted from an M3U reference file.
-// Keyed by channel name for matching with Jellyfin channels.
-struct M3UCatchupInfo
+// Per-channel record extracted from a reference M3U.
+// Keyed by channel name (case-insensitive) for matching with Jellyfin channels.
+struct M3UChannelInfo
 {
-  CatchupMode mode = CatchupMode::DISABLED;
-  int days = 0;
-  std::string source;      // catchup-source format string
-  float correctionHours = 0.0f;
+  // Catchup
+  CatchupMode catchupMode = CatchupMode::DISABLED;
+  int catchupDays = 0;
+  std::string catchupSource;
+  float catchupCorrectionHours = 0.0f;
   bool hasCatchup = false;
+
+  // Channel groups (semicolon-split from group-title= and #EXTGRP:)
+  std::vector<std::string> groupNames;
+
+  // Optional logo override (tvg-logo)
+  std::string tvgLogo;
+
+  // Properties to forward to Kodi (inputstream.*, mimetype, etc.)
+  std::map<std::string, std::string> kodiProps;
+
+  // KofinProps consumed by BuildDeviceProfile (kofin-force-remux,
+  // kofin-bitrate-limit, kofin-force-transcode). Stored separately so they
+  // don't leak into Kodi PVRStreamProperty output.
+  std::map<std::string, std::string> kofinProps;
 };
 
 class M3UParser
@@ -34,18 +50,19 @@ class M3UParser
 public:
   M3UParser(std::shared_ptr<InstanceSettings>& settings);
 
-  // Parse the reference M3U and populate the catchup map.
+  // Parse the reference M3U and populate the channel-info map.
   // Supports local files and HTTP/HTTPS URLs.
   bool Parse();
 
-  // Look up catchup info for a channel by name (case-insensitive).
-  const M3UCatchupInfo* GetCatchupInfo(const std::string& channelName) const;
+  // Look up info for a channel by name (case-insensitive).
+  const M3UChannelInfo* GetChannelInfo(const std::string& channelName) const;
+
+  // All unique group names encountered in the playlist, in first-seen order.
+  const std::vector<std::string>& GetAllGroupNames() const { return m_allGroupNames; }
 
 private:
-  std::string ReadMarkerValue(const std::string& line, const std::string& marker) const;
-  CatchupMode ParseCatchupMode(const std::string& modeStr) const;
-
-  std::map<std::string, M3UCatchupInfo> m_catchupMap;  // lowercase name → info
+  std::map<std::string, M3UChannelInfo> m_channels;     // lowercase name → info
+  std::vector<std::string> m_allGroupNames;             // unique, first-seen order
   std::shared_ptr<InstanceSettings> m_settings;
 };
 

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -29,6 +29,49 @@ using namespace iptvsimple::data;
 using namespace iptvsimple::jellyfin;
 using namespace iptvsimple::utilities;
 
+namespace
+{
+bool ParseBoolProp(const std::string& value)
+{
+  std::string v = value;
+  std::transform(v.begin(), v.end(), v.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return v == "true" || v == "1" || v == "yes" || v == "on";
+}
+} // unnamed namespace
+
+ChannelOverrides ChannelOverrides::FromChannel(const Channel& channel)
+{
+  ChannelOverrides o;
+  const auto& props = channel.GetProperties();
+
+  auto get = [&](const std::string& key) -> const std::string* {
+    auto it = props.find(key);
+    return (it != props.end()) ? &it->second : nullptr;
+  };
+
+  if (const auto* v = get("kofin-force-remux"))
+    o.forceRemux = ParseBoolProp(*v);
+  if (const auto* v = get("kofin-force-transcode"))
+    o.forceTranscode = ParseBoolProp(*v);
+  if (const auto* v = get("kofin-bitrate-limit"))
+  {
+    int kbps = std::atoi(v->c_str());
+    if (kbps > 0)
+      o.bitrateBps = kbps * 1000;
+    else
+      o.bitrateBps = 1000000000; // unlimited sentinel matching GetMaxBitrateBps()
+  }
+
+  // Inputstream override drives container selection in BuildDeviceProfile.
+  if (const auto* v = get(PVR_STREAM_PROPERTY_INPUTSTREAM))
+    o.inputstream = *v;
+  else if (const auto* v = get("inputstream"))
+    o.inputstream = *v;
+
+  return o;
+}
+
 JellyfinChannelLoader::JellyfinChannelLoader(
     std::shared_ptr<JellyfinClient> client,
     std::shared_ptr<iptvsimple::InstanceSettings> settings)
@@ -61,13 +104,34 @@ bool JellyfinChannelLoader::LoadChannels(Channels& channels, ChannelGroups& chan
     return true;
   }
 
-  // Create "All Channels" group
+  // Parse the reference playlist up-front so its data is available when each
+  // channel is added to the channels/groups stores.
+  M3UParser m3uParser(m_settings);
+  bool m3uLoaded = false;
+  if (m_settings->ReferencePlaylistEnabled() && !m_settings->GetReferencePlaylistPath().empty())
+    m3uLoaded = m3uParser.Parse();
+
+  // Always create the "Jellyfin" all-channels group.
   ChannelGroup allGroup;
   allGroup.SetGroupName("Jellyfin");
   allGroup.SetRadio(false);
-  int groupId = channelGroups.AddChannelGroup(allGroup);
+  const int jellyfinGroupId = channelGroups.AddChannelGroup(allGroup);
+
+  // Pre-create groups discovered in the reference playlist (preserves order).
+  std::map<std::string, int> m3uGroupIdByName;
+  if (m3uLoaded)
+  {
+    for (const auto& name : m3uParser.GetAllGroupNames())
+    {
+      ChannelGroup g;
+      g.SetGroupName(name);
+      g.SetRadio(false);
+      m3uGroupIdByName[name] = channelGroups.AddChannelGroup(g);
+    }
+  }
 
   int channelNumber = 1;
+  int matchedCount = 0;
 
   for (const auto& item : items)
   {
@@ -108,58 +172,68 @@ bool JellyfinChannelLoader::LoadChannels(Channels& channels, ChannelGroups& chan
     // Stream URL placeholder - actual URL resolved via PlaybackInfo in GetChannelStreamProperties
     channel.SetStreamURL(m_client->GetBaseUrl() + "/LiveTv/Channels/" + jellyfinId);
 
-    // Add channel (AddChannel sets the unique ID via its hash function)
-    std::vector<int> groupIdList = {groupId};
+    // Always-include the "Jellyfin" group; M3U groups are added per-match.
+    std::vector<int> groupIdList = {jellyfinGroupId};
+
+    // Apply reference-playlist data
+    if (m3uLoaded)
+    {
+      const M3UChannelInfo* info = m3uParser.GetChannelInfo(name);
+      if (info)
+      {
+        // Catchup (only when catchup is enabled by the user)
+        if (m_settings->CatchupEnabled() && info->hasCatchup)
+        {
+          channel.SetHasCatchup(true);
+          channel.SetCatchupMode(info->catchupMode);
+          channel.SetCatchupDays(info->catchupDays > 0 ? info->catchupDays : m_settings->GetCatchupDays());
+          if (!info->catchupSource.empty())
+            channel.SetCatchupSource(info->catchupSource);
+          if (info->catchupCorrectionHours != 0.0f)
+            channel.SetCatchupCorrectionSecs(static_cast<int>(info->catchupCorrectionHours * 3600.0f));
+          channel.ConfigureCatchupMode();
+        }
+
+        // KodiProps (inputstream.*, mimetype, http-*)
+        for (const auto& kv : info->kodiProps)
+          channel.AddProperty(kv.first, kv.second);
+
+        // KofinProps (kofin-*) — stored on the channel; consumed by ChannelOverrides::FromChannel
+        for (const auto& kv : info->kofinProps)
+          channel.AddProperty(kv.first, kv.second);
+
+        // Logo override
+        if (!info->tvgLogo.empty())
+          channel.SetIconPath(info->tvgLogo);
+
+        // M3U-defined groups (additive to the Jellyfin fallback)
+        for (const auto& gname : info->groupNames)
+        {
+          auto it = m3uGroupIdByName.find(gname);
+          if (it != m3uGroupIdByName.end())
+            groupIdList.push_back(it->second);
+        }
+
+        matchedCount++;
+      }
+    }
+
     if (channels.AddChannel(channel, groupIdList, channelGroups, true))
     {
       int uid = channel.GetUniqueId();
       m_jellyfinIdToUid[jellyfinId] = uid;
       m_uidToJellyfinId[uid] = jellyfinId;
 
-      Logger::Log(LEVEL_DEBUG, "%s - Added channel '%s' (uid=%d, jellyfinId=%s)",
-                  __FUNCTION__, name.c_str(), uid, jellyfinId.c_str());
+      Logger::Log(LEVEL_DEBUG, "%s - Added channel '%s' (uid=%d, jellyfinId=%s, groups=%zu)",
+                  __FUNCTION__, name.c_str(), uid, jellyfinId.c_str(), groupIdList.size());
     }
   }
 
   channelGroups.RemoveEmptyGroups();
 
-  // Apply catchup metadata from reference M3U (if configured)
-  if (m_settings->CatchupEnabled() && !m_settings->GetCatchupM3UPath().empty())
-  {
-    M3UParser m3uParser(m_settings);
-    if (m3uParser.Parse())
-    {
-      int matched = 0;
-      for (auto& channel : channels.GetChannelsListMutable())
-      {
-        const M3UCatchupInfo* info = m3uParser.GetCatchupInfo(channel.GetChannelName());
-        if (info && info->hasCatchup)
-        {
-          channel.SetHasCatchup(true);
-          channel.SetCatchupMode(info->mode);
-          channel.SetCatchupDays(info->days > 0 ? info->days : m_settings->GetCatchupDays());
-          if (!info->source.empty())
-            channel.SetCatchupSource(info->source);
-          if (info->correctionHours != 0.0f)
-            channel.SetCatchupCorrectionSecs(static_cast<int>(info->correctionHours * 3600.0f));
-
-          // Generate the catchup source URL from mode + stream URL
-          channel.ConfigureCatchupMode();
-
-          Logger::Log(LEVEL_DEBUG, "%s - Catchup matched '%s': mode=%d, days=%d, source='%s'",
-                      __FUNCTION__, channel.GetChannelName().c_str(),
-                      static_cast<int>(channel.GetCatchupMode()),
-                      channel.GetCatchupDays(),
-                      channel.GetCatchupSource().c_str());
-          matched++;
-        }
-      }
-      Logger::Log(LEVEL_INFO, "%s - Matched %d channels with catchup from reference M3U", __FUNCTION__, matched);
-    }
-  }
-
-  Logger::Log(LEVEL_INFO, "%s - Loaded %d channels from Jellyfin",
-              __FUNCTION__, static_cast<int>(items.size()));
+  Logger::Log(LEVEL_INFO,
+              "%s - Loaded %d channels from Jellyfin (%d matched in reference playlist)",
+              __FUNCTION__, static_cast<int>(items.size()), matchedCount);
   return true;
 }
 
@@ -259,12 +333,15 @@ PVR_ERROR JellyfinChannelLoader::LoadEpg(int channelUid, time_t start, time_t en
   return PVR_ERROR_NO_ERROR;
 }
 
-Json::Value JellyfinChannelLoader::BuildDeviceProfile()
+Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& overrides)
 {
   const std::string preferredVideo = m_settings->GetPreferredVideoCodecName();
   const std::string preferredAudio = m_settings->GetPreferredAudioCodecName();
-  const int maxBitrateBps = m_settings->GetMaxBitrateBps();
-  const bool forceTranscode = m_settings->GetForceTranscode();
+
+  // Per-channel overrides win over global settings; otherwise fall back.
+  const int maxBitrateBps = overrides.bitrateBps.value_or(m_settings->GetMaxBitrateBps());
+  const bool forceRemux = overrides.forceRemux.value_or(m_settings->GetForceTranscode());
+  const bool forceTranscodeOverride = overrides.forceTranscode.value_or(false);
 
   Json::Value profile;
   profile["Name"] = "Kodi";
@@ -281,58 +358,108 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile()
       audioCodecs += std::string(",") + codec;
   }
 
+  // Allowed video codecs after applying global force-transcode toggles.
+  // Codec excluded here cannot direct-play and cannot be remuxed (codec-copied);
+  // the server will fall back to transcoding to the preferred codec.
+  std::vector<std::string> allowedVideoCodecs = {"av1", "h264", "hevc", "mpeg2video", "vp9", "vc1"};
+  auto excludeCodec = [&](bool toggle, const std::string& codec) {
+    if (toggle)
+      allowedVideoCodecs.erase(std::remove(allowedVideoCodecs.begin(), allowedVideoCodecs.end(), codec),
+                               allowedVideoCodecs.end());
+  };
+  excludeCodec(m_settings->GetForceTranscodeAV1(),   "av1");
+  excludeCodec(m_settings->GetForceTranscodeHEVC(),  "hevc");
+  excludeCodec(m_settings->GetForceTranscodeMPEG2(), "mpeg2video");
+  excludeCodec(m_settings->GetForceTranscodeVC1(),   "vc1");
+  excludeCodec(m_settings->GetForceTranscodeVP9(),   "vp9");
+
+  std::string allowedVideoCodecsCsv;
+  for (const auto& c : allowedVideoCodecs)
+  {
+    if (!allowedVideoCodecsCsv.empty())
+      allowedVideoCodecsCsv += ",";
+    allowedVideoCodecsCsv += c;
+  }
+
   const bool bitrateUnlimited = (maxBitrateBps >= 1000000000);
 
+  // Container choice: TS for everything except AV1 (which can't ride MPEG-TS).
+  // inputstream.adaptive accepts HLS+TS as long as we hand it the master
+  // playlist (with the CODECS="avc1.X,mp4a.X" attribute) instead of the bare
+  // media playlist — the master provides codec extradata so adaptive doesn't
+  // have to demux TS segments to find SPS/PPS. The master vs live URL choice
+  // is handled by PostProcessTranscodingUrl, not here.
+  const std::string container = (preferredVideo == "av1") ? "mp4" : "ts";
+
+  // MinSegments controls how many transcoded segments Jellyfin generates
+  // before returning the variant playlist. ffmpegdirect tolerates a 1-segment
+  // initial playlist (it polls), but inputstream.adaptive rejects it with
+  // "Codec id NN require extradata" — adaptive won't trust the master's
+  // CODECS attribute when the variant has only one segment, and won't poll
+  // for more. Buffering 3 segments first gives adaptive a populated playlist
+  // that matches the recording-playback shape (which always works). Costs
+  // ~10s of startup latency — acceptable trade for adaptive users.
+  const bool useAdaptive = overrides.inputstream.value_or("") == "inputstream.adaptive";
+  const std::string minSegments = useAdaptive ? "3" : "1";
+
   // TranscodingProfiles:
-  // - Force remux ON + unlimited bitrate → codec-copy into TS (remux)
-  // - All other cases → preferred codec only (AV1→fMP4, others→TS)
-  //   Covers: force remux with bitrate limit, no force remux with bitrate
-  //   limit exceeded, codec profile mismatch, etc.
+  // - Remux mode (forceRemux ON + unlimited bitrate + no per-channel forceTranscode)
+  //   → codec-copy the allowed codecs.
+  // - Otherwise → preferred codec only.
   Json::Value transcodingProfiles(Json::arrayValue);
 
-  if (forceTranscode && bitrateUnlimited)
+  const bool remuxMode = forceRemux && bitrateUnlimited && !forceTranscodeOverride;
+
+  if (remuxMode)
   {
-    // Remux: codec-copy all non-AV1 codecs into TS.
     Json::Value tp;
-    tp["Container"] = "ts";
+    tp["Container"] = container;
     tp["Type"] = "Video";
     tp["AudioCodec"] = audioCodecs;
-    tp["VideoCodec"] = "h264,hevc,mpeg2video";
+    // TS can't carry AV1; drop it from the codec-copy list when staying on TS.
+    std::string remuxCodecs;
+    for (const auto& c : allowedVideoCodecs)
+    {
+      if (c == "av1" && container == "ts")
+        continue;
+      if (!remuxCodecs.empty())
+        remuxCodecs += ",";
+      remuxCodecs += c;
+    }
+    tp["VideoCodec"] = remuxCodecs;
     tp["Context"] = "Streaming";
     tp["Protocol"] = "hls";
     tp["MaxAudioChannels"] = "6";
-    tp["MinSegments"] = "1";
+    tp["MinSegments"] = minSegments;
     tp["BreakOnNonKeyFrames"] = true;
     transcodingProfiles.append(tp);
   }
   else
   {
-    // Transcode to preferred codec.
-    // AV1 → fMP4 (AV1 can't go in MPEG-TS), everything else → TS.
     Json::Value tp;
-    tp["Container"] = (preferredVideo == "av1") ? "mp4" : "ts";
+    tp["Container"] = container;
     tp["Type"] = "Video";
     tp["AudioCodec"] = audioCodecs;
     tp["VideoCodec"] = preferredVideo;
     tp["Context"] = "Streaming";
     tp["Protocol"] = "hls";
     tp["MaxAudioChannels"] = "6";
-    tp["MinSegments"] = "1";
+    tp["MinSegments"] = minSegments;
     tp["BreakOnNonKeyFrames"] = true;
     transcodingProfiles.append(tp);
   }
   profile["TranscodingProfiles"] = transcodingProfiles;
 
-  // Direct play only when force remux is off AND no bitrate limit.
-  // For live TV (Protocol=Http), Jellyfin ignores MaxStreamingBitrate
-  // for DirectPlay decisions, so we must clear DirectPlayProfiles to
-  // force the server to use TranscodingProfiles when a limit is set.
+  // Direct play only when neither remux nor transcode is forced AND no
+  // bitrate limit. For live TV (Protocol=Http), Jellyfin ignores
+  // MaxStreamingBitrate for DirectPlay decisions, so we must clear
+  // DirectPlayProfiles to force TranscodingProfiles when a limit is set.
   Json::Value directPlayProfiles(Json::arrayValue);
-  if (!forceTranscode && bitrateUnlimited)
+  if (!forceRemux && !forceTranscodeOverride && bitrateUnlimited && !allowedVideoCodecs.empty())
   {
     Json::Value v;
     v["Type"] = "Video";
-    v["VideoCodec"] = "av1,h264,hevc,mpeg2video";
+    v["VideoCodec"] = allowedVideoCodecsCsv;
     directPlayProfiles.append(v);
     Json::Value a;
     a["Type"] = "Audio";
@@ -340,9 +467,12 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile()
   }
   profile["DirectPlayProfiles"] = directPlayProfiles;
 
-  // Codec profiles: constrain direct play to codecs the device can actually decode
+  // Codec profiles: constrain direct play to codecs the device can actually decode.
+  // These are no-ops when the codec is already excluded from DirectPlayProfiles.
   Json::Value codecProfiles(Json::arrayValue);
-  if (m_settings->GetTranscodeHi10P())
+  const bool h264Allowed = std::find(allowedVideoCodecs.begin(), allowedVideoCodecs.end(), "h264") != allowedVideoCodecs.end();
+  const bool hevcAllowed = std::find(allowedVideoCodecs.begin(), allowedVideoCodecs.end(), "hevc") != allowedVideoCodecs.end();
+  if (h264Allowed && m_settings->GetTranscodeHi10P())
   {
     Json::Value cp;
     cp["Type"] = "Video";
@@ -355,7 +485,7 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile()
     cp["Conditions"].append(cond);
     codecProfiles.append(cp);
   }
-  if (m_settings->GetTranscodeHevcRext())
+  if (hevcAllowed && m_settings->GetTranscodeHevcRext())
   {
     Json::Value cp;
     cp["Type"] = "Video";
@@ -537,12 +667,16 @@ std::string JellyfinChannelLoader::GetRecordingStreamUrl(const std::string& reco
 }
 
 std::string JellyfinChannelLoader::PostProcessTranscodingUrl(
-    const std::string& transcodingUrl)
+    const std::string& transcodingUrl, bool keepMaster)
 {
   // Post-process TranscodingUrl to match jellyfin-kodi behaviour:
-  // - Replace "stream"/"master" with "live" for live TV
-  // - Recalculate audio/video bitrates
-  // SegmentContainer is left as-is (set correctly by server via dual TranscodingProfiles)
+  // - For ffmpegdirect/internal: replace "stream"/"master" with "live" so we
+  //   land on Jellyfin's bare media playlist (preferred by ffmpegdirect).
+  // - For inputstream.adaptive: keep "master" so we hit Jellyfin's master
+  //   playlist endpoint, which wraps the media playlist with proper
+  //   #EXT-X-STREAM-INF + CODECS attributes that adaptive needs to
+  //   construct codec extradata before opening segments.
+  // - Recalculate audio/video bitrates either way.
 
   auto qPos = transcodingUrl.find('?');
   if (qPos == std::string::npos)
@@ -568,8 +702,10 @@ std::string JellyfinChannelLoader::PostProcessTranscodingUrl(
     return p.find("AudioBitrate=") == 0 || p.find("VideoBitrate=") == 0;
   }), params.end());
 
-  // Recalculate bitrates
-  const int maxBitrateBps = m_settings->GetMaxBitrateBps();
+  // Recalculate bitrates using the per-session limit (overrides applied at
+  // GetItemStreamUrl time; falls back to the global setting).
+  const int maxBitrateBps = m_activeMaxBitrateBps > 0
+    ? m_activeMaxBitrateBps : m_settings->GetMaxBitrateBps();
   const int audioBitrate = 384000;
   const int videoBitrate = maxBitrateBps - audioBitrate;
 
@@ -584,11 +720,15 @@ std::string JellyfinChannelLoader::PostProcessTranscodingUrl(
   newParams += "&VideoBitrate=" + std::to_string(videoBitrate);
   newParams += "&AudioBitrate=" + std::to_string(audioBitrate);
 
-  // Replace "stream" or "master" with "live" in URL path for live TV
-  std::string search = (base.find("stream") != std::string::npos) ? "stream" : "master";
-  auto pos = base.find(search);
-  if (pos != std::string::npos)
-    base.replace(pos, search.length(), "live");
+  // Replace "stream"/"master" with "live" in URL path for live TV — unless
+  // the caller asked us to keep the master endpoint (adaptive needs it).
+  if (!keepMaster)
+  {
+    std::string search = (base.find("stream") != std::string::npos) ? "stream" : "master";
+    auto pos = base.find(search);
+    if (pos != std::string::npos)
+      base.replace(pos, search.length(), "live");
+  }
 
   return m_client->GetBaseUrl() + base + "?" + newParams;
 }
@@ -611,12 +751,14 @@ void JellyfinChannelLoader::RewriteLocalhost(std::string& url)
   }
 }
 
-std::string JellyfinChannelLoader::GetLiveStreamUrl(const std::string& channelId)
+std::string JellyfinChannelLoader::GetLiveStreamUrl(const std::string& channelId,
+                                                    const ChannelOverrides& overrides)
 {
-  return GetItemStreamUrl(channelId);
+  return GetItemStreamUrl(channelId, overrides);
 }
 
-std::string JellyfinChannelLoader::GetItemStreamUrl(const std::string& itemId)
+std::string JellyfinChannelLoader::GetItemStreamUrl(const std::string& itemId,
+                                                    const ChannelOverrides& overrides)
 {
   Logger::Log(LEVEL_DEBUG, "%s - Getting stream URL for item %s", __FUNCTION__, itemId.c_str());
 
@@ -628,8 +770,11 @@ std::string JellyfinChannelLoader::GetItemStreamUrl(const std::string& itemId)
 
   Json::Value body;
   body["UserId"] = m_client->GetUserId();
-  body["DeviceProfile"] = BuildDeviceProfile();
+  body["DeviceProfile"] = BuildDeviceProfile(overrides);
   body["AutoOpenLiveStream"] = true;
+  // Stash the override bitrate for PostProcessTranscodingUrl, which the server
+  // will echo into the URL params we then rewrite.
+  m_activeMaxBitrateBps = overrides.bitrateBps.value_or(m_settings->GetMaxBitrateBps());
 
   Json::StreamWriterBuilder writer;
   writer["indentation"] = "";
@@ -670,7 +815,8 @@ std::string JellyfinChannelLoader::GetItemStreamUrl(const std::string& itemId)
   // matching jellyfin-kodi's transcode() method (stream→live rewrite, bitrate recalc).
   if (hasTranscodingUrl)
   {
-    streamUrl = PostProcessTranscodingUrl(source["TranscodingUrl"].asString());
+    const bool keepMaster = overrides.inputstream.value_or("") == "inputstream.adaptive";
+    streamUrl = PostProcessTranscodingUrl(source["TranscodingUrl"].asString(), keepMaster);
   }
   else if (source.isMember("Path") && !source["Path"].asString().empty())
   {

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
@@ -9,10 +9,12 @@
 
 #include "../Channels.h"
 #include "../ChannelGroups.h"
+#include "../data/Channel.h"
 #include "JellyfinClient.h"
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -23,6 +25,23 @@ namespace iptvsimple
 namespace jellyfin
 {
 
+// Per-channel overrides extracted from M3U KofinProps. Forwarded to
+// BuildDeviceProfile so a single channel can override the global
+// transcode/bitrate policy.
+struct ChannelOverrides
+{
+  std::optional<bool> forceRemux;        // kofin-force-remux
+  std::optional<int>  bitrateBps;         // kofin-bitrate-limit (kbps × 1000)
+  std::optional<bool> forceTranscode;     // kofin-force-transcode
+  // inputstream override (PVR_STREAM_PROPERTY_INPUTSTREAM from M3U KodiProps).
+  // Drives Jellyfin device-profile Container choice — inputstream.adaptive
+  // can only consume fMP4 for HEVC/AV1, while ffmpegdirect prefers TS.
+  std::optional<std::string> inputstream;
+
+  bool Empty() const { return !forceRemux && !bitrateBps && !forceTranscode && !inputstream; }
+  static ChannelOverrides FromChannel(const iptvsimple::data::Channel& channel);
+};
+
 class JellyfinChannelLoader
 {
 public:
@@ -32,8 +51,10 @@ public:
   bool LoadChannels(iptvsimple::Channels& channels, iptvsimple::ChannelGroups& channelGroups);
   PVR_ERROR LoadEpg(int channelUid, time_t start, time_t end,
                      kodi::addon::PVREPGTagsResultSet& results);
-  std::string GetLiveStreamUrl(const std::string& channelId);
-  std::string GetItemStreamUrl(const std::string& itemId);
+  std::string GetLiveStreamUrl(const std::string& channelId,
+                                const ChannelOverrides& overrides = {});
+  std::string GetItemStreamUrl(const std::string& itemId,
+                                const ChannelOverrides& overrides = {});
   std::string GetRecordingStreamUrl(const std::string& recordingId);
   void CloseLiveStream();
 
@@ -47,9 +68,9 @@ private:
   static int GenerateUid(const std::string& str);
   static std::string FormatIso8601(time_t time);
   static time_t ParseIso8601(const std::string& dateStr);
-  Json::Value BuildDeviceProfile();
+  Json::Value BuildDeviceProfile(const ChannelOverrides& overrides);
   Json::Value BuildRecordingDeviceProfile();
-  std::string PostProcessTranscodingUrl(const std::string& transcodingUrl);
+  std::string PostProcessTranscodingUrl(const std::string& transcodingUrl, bool keepMaster);
   void RewriteLocalhost(std::string& url);
 
   // Jellyfin channel ID <-> Kodi channel UID mappings
@@ -66,6 +87,7 @@ private:
   std::string m_activePlaySessionId;
   std::string m_activePlayMethod;         // "DirectPlay" or "Transcode"
   bool m_activeIsRecording{false};
+  int m_activeMaxBitrateBps{0};            // bitrate ceiling used for current session (override-aware)
 
   std::shared_ptr<JellyfinClient> m_client;
   std::shared_ptr<iptvsimple::InstanceSettings> m_settings;


### PR DESCRIPTION
Promotes the reference M3U from a narrow catchup-metadata layer to a per-channel override mechanism: channel groups, KodiProps (inputstream selection, mimetype, http headers), and new KofinProps (kofin-force-remux, kofin-bitrate-limit, kofin-force-transcode) all flow from the M3U into the Jellyfin device profile + Kodi stream properties.

Settings reorganised: Playback split into Transcoding + InputStream; M3U path moved from Catchup into a new Reference playlist group under Advanced, with a one-shot migration from the legacy catchupM3U keys. Five new global force-transcode codec toggles (AV1/HEVC/MPEG-2/VC-1/VP9) filter the device profile's video codec lists.

Adaptive playback for transcoded/remuxed live TV now works: master.m3u8 is preserved (instead of rewriting to live.m3u8) so adaptive sees the CODECS attribute, and MinSegments=3 is set in the device profile so the first variant playlist comes back with enough segments for adaptive's parser to trust the master's codec metadata. ffmpegdirect path keeps the original live.m3u8 / MinSegments=1 behaviour.

See changelog for the full per-version progression (0.6.0 through 0.6.5).

Fixes: https://github.com/kontell/pvr.kofin/issues/6