### PR TITLE
Simplify device profile and add "Force transcoding" setting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
 env:
   app_id: pvr.kofin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 on:
   push:
     tags: ['v*']
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:

--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.6.9"
+  version="0.7.0"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.6.8"
+  version="0.6.9"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/changelog.txt
+++ b/pvr.kofin/changelog.txt
@@ -1,3 +1,13 @@
+v0.7.0
+- Unified TranscodingProfile: single profile with preferred codec first, then all allowed codecs — server codec-copies when it can, transcodes to preferred when it must
+- Add "Force transcoding" global setting — caps bitrate at source to force re-encode to preferred codec (previously per-channel only via kofin-force-transcode)
+- Fix fMP4 container crash on in-progress recordings: profile always requests TS, PostProcessTranscodingUrl switches to fMP4 only for actual AV1 video transcodes
+- Preferred video codec included in DirectPlayProfiles — setting a preferred codec implies the device can decode it
+- DTS added to audio codec options
+- Session metadata moved from Kodi settings to file — eliminates "Unknown setting type" log spam for list[string] codec settings
+- Release build matrix now runs on pull requests for cross-platform compile verification
+- Fix doubled CI checks on PRs
+
 v0.6.8
 - Replace per-codec force-transcode toggles with multi-select Direct play video/audio codec lists
 - Add MP2 to the audio codec list (common in DVB broadcasts)

--- a/pvr.kofin/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.kofin/resources/language/resource.language.en_gb/strings.po
@@ -516,6 +516,18 @@ msgctxt "#30801"
 msgid "FLAC"
 msgstr ""
 
+msgctxt "#30805"
+msgid "DTS"
+msgstr ""
+
+msgctxt "#30806"
+msgid "Force transcoding"
+msgstr ""
+
+msgctxt "#30807"
+msgid "Force the server to transcode to the preferred video codec instead of remuxing. The bitrate is capped at the source bitrate (or the maximum streaming bitrate, whichever is lower) to trigger re-encoding."
+msgstr ""
+
 msgctxt "#30802"
 msgid "H264 10-bit"
 msgstr ""

--- a/pvr.kofin/resources/scripts/service.py
+++ b/pvr.kofin/resources/scripts/service.py
@@ -5,23 +5,18 @@ Uses xbmc.Player callbacks for start/stop/pause detection and urllib for HTTP
 (bypasses Kodi's curl pool entirely, avoiding the UI-hang bug from C++ reporter).
 """
 import json
+import os
 import time
 import urllib.request
 import urllib.error
 
 import xbmc
 import xbmcaddon
+import xbmcvfs
 
 
 ADDON_ID = 'pvr.kofin'
 REPORT_INTERVAL = 10  # seconds between progress reports
-SESSION_KEYS = (
-    'sessionItemId',
-    'sessionMediaSourceId',
-    'sessionPlaySessionId',
-    'sessionLiveStreamId',
-    'sessionPlayMethod',
-)
 
 
 def get_device_name():
@@ -81,7 +76,15 @@ class PlaybackReporter(xbmc.Player):
             return
 
         addon = xbmcaddon.Addon(ADDON_ID)
-        item_id = addon.getSetting('sessionItemId')
+        session_path = os.path.join(
+            xbmcvfs.translatePath(addon.getAddonInfo('profile')),
+            'session.json')
+        try:
+            with open(session_path, 'r') as f:
+                session_data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return
+        item_id = session_data.get('ItemId', '')
         if not item_id:
             return
 
@@ -89,10 +92,10 @@ class PlaybackReporter(xbmc.Player):
         self.last_position_ticks = 0
         self.session = {
             'ItemId': item_id,
-            'MediaSourceId': addon.getSetting('sessionMediaSourceId'),
-            'PlaySessionId': addon.getSetting('sessionPlaySessionId'),
-            'LiveStreamId': addon.getSetting('sessionLiveStreamId'),
-            'PlayMethod': addon.getSetting('sessionPlayMethod'),
+            'MediaSourceId': session_data.get('MediaSourceId', ''),
+            'PlaySessionId': session_data.get('PlaySessionId', ''),
+            'LiveStreamId': session_data.get('LiveStreamId', ''),
+            'PlayMethod': session_data.get('PlayMethod', ''),
             'BaseUrl': addon.getSetting('jellyfinServerAddress'),
             'Token': addon.getSetting('jellyfinAccessToken'),
             'DeviceId': addon.getSetting('deviceId'),
@@ -141,8 +144,13 @@ class PlaybackReporter(xbmc.Player):
         # Clear persisted session so the next non-kofin playback (e.g. a music
         # track from another addon) isn't misreported as a resumed kofin session.
         addon = xbmcaddon.Addon(ADDON_ID)
-        for key in SESSION_KEYS:
-            addon.setSetting(key, '')
+        session_path = os.path.join(
+            xbmcvfs.translatePath(addon.getAddonInfo('profile')),
+            'session.json')
+        try:
+            os.remove(session_path)
+        except OSError:
+            pass
 
         xbmc.log('pvr.kofin reporter: playback stopped', xbmc.LOGINFO)
 

--- a/pvr.kofin/resources/settings.xml
+++ b/pvr.kofin/resources/settings.xml
@@ -114,36 +114,6 @@
             <close>true</close>
           </control>
         </setting>
-        <setting id="sessionItemId" type="string">
-          <level>4</level>
-          <default></default>
-          <constraints><allowempty>true</allowempty></constraints>
-          <control type="edit" format="string" />
-        </setting>
-        <setting id="sessionMediaSourceId" type="string">
-          <level>4</level>
-          <default></default>
-          <constraints><allowempty>true</allowempty></constraints>
-          <control type="edit" format="string" />
-        </setting>
-        <setting id="sessionPlaySessionId" type="string">
-          <level>4</level>
-          <default></default>
-          <constraints><allowempty>true</allowempty></constraints>
-          <control type="edit" format="string" />
-        </setting>
-        <setting id="sessionLiveStreamId" type="string">
-          <level>4</level>
-          <default></default>
-          <constraints><allowempty>true</allowempty></constraints>
-          <control type="edit" format="string" />
-        </setting>
-        <setting id="sessionPlayMethod" type="string">
-          <level>4</level>
-          <default></default>
-          <constraints><allowempty>true</allowempty></constraints>
-          <control type="edit" format="string" />
-        </setting>
         <setting id="jellyfinAccessToken" type="string">
           <level>4</level>
           <default></default>

--- a/pvr.kofin/resources/settings.xml
+++ b/pvr.kofin/resources/settings.xml
@@ -198,6 +198,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="forceTranscoding" type="boolean" label="30806" help="30807">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="directPlayVideoCodecs" type="list[string]" label="30781" help="30782">
           <level>0</level>
           <default>h264,h264_10bit,hevc,hevc_rext,av1,mpeg2video,vp9,vc1</default>
@@ -221,7 +226,7 @@
         </setting>
         <setting id="directPlayAudioCodecs" type="list[string]" label="30783" help="30784">
           <level>0</level>
-          <default>aac,mp2,mp3,ac3,eac3,opus,flac</default>
+          <default>aac,mp2,mp3,ac3,eac3,opus,flac,dts</default>
           <constraints>
             <options>
               <option label="30631">aac</option>
@@ -231,6 +236,7 @@
               <option label="30800">eac3</option>
               <option label="30715">opus</option>
               <option label="30801">flac</option>
+              <option label="30805">dts</option>
             </options>
             <delimiter>,</delimiter>
           </constraints>

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build pvr.kofin locally and create an installable zip.
+#
+# Usage: ./scripts/build-local.sh [--debug]
+#
+# Requires: Kodi v21 source at /media/bluecon/docs/dev/ref/kodi-omega-full/
+# Output:   /media/bluecon/docs/IT/kofin/builds/pvr.kofin-<ver>-linux-x86_64-omega.zip
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ADDON_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+KODI_SRC="/media/bluecon/docs/dev/ref/kodi-omega-full"
+BUILDS_DIR="/media/bluecon/docs/dev/builds"
+
+BUILD_TYPE="Release"
+[[ "${1:-}" == "--debug" ]] && BUILD_TYPE="Debug"
+
+ADDON_VERSION=$(grep 'version=' "$ADDON_DIR/pvr.kofin/addon.xml.in" | head -1 | sed 's/.*version="\([^"]*\)".*/\1/')
+ZIP_NAME="pvr.kofin-${ADDON_VERSION}-linux-x86_64-omega.zip"
+INSTALL_DIR="$KODI_SRC/build/addons"
+
+echo "Building pvr.kofin $ADDON_VERSION ($BUILD_TYPE)"
+
+cd "$ADDON_DIR/build"
+cmake -DADDONS_TO_BUILD=pvr.kofin \
+      -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+      -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+      -DPACKAGE_ZIP=1 \
+      "$KODI_SRC/cmake/addons"
+make -j"$(nproc)"
+
+echo "Packaging $ZIP_NAME"
+mkdir -p "$BUILDS_DIR"
+cd "$INSTALL_DIR"
+zip -r "$BUILDS_DIR/$ZIP_NAME" pvr.kofin/
+
+
+echo "Output: $BUILDS_DIR/$ZIP_NAME"

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -16,7 +16,7 @@ BUILDS_DIR="/media/bluecon/docs/dev/builds"
 BUILD_TYPE="Release"
 [[ "${1:-}" == "--debug" ]] && BUILD_TYPE="Debug"
 
-ADDON_VERSION=$(grep 'version=' "$ADDON_DIR/pvr.kofin/addon.xml.in" | head -1 | sed 's/.*version="\([^"]*\)".*/\1/')
+ADDON_VERSION=$(sed -n '/<?xml/!s/.*version="\([^"]*\)".*/\1/p' "$ADDON_DIR/pvr.kofin/addon.xml.in" | head -1)
 ZIP_NAME="pvr.kofin-${ADDON_VERSION}-linux-x86_64-omega.zip"
 INSTALL_DIR="$KODI_SRC/build/addons"
 

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -1107,18 +1107,12 @@ void IptvSimple::OnSettingChanged(const std::string& settingName, const kodi::ad
 
   // list[string] settings can't be read by GetSettingString — capture them
   // here where TransferSettings delivers the value as a plain string.
-  // Session SetSettingString calls re-trigger TransferSettings which
-  // re-delivers codec lists with stale values from the XML round-trip,
-  // so skip capture when the suppress flag is set around those writes.
   if (settingName == "directPlayVideoCodecs" || settingName == "directPlayAudioCodecs")
   {
-    if (!m_settings->GetSuppressCodecCapture())
-    {
-      if (settingName == "directPlayVideoCodecs")
-        m_settings->SetDirectPlayVideoCodecs(settingValue.GetString());
-      else
-        m_settings->SetDirectPlayAudioCodecs(settingValue.GetString());
-    }
+    if (settingName == "directPlayVideoCodecs")
+      m_settings->SetDirectPlayVideoCodecs(settingValue.GetString());
+    else
+      m_settings->SetDirectPlayAudioCodecs(settingValue.GetString());
     return;
   }
 

--- a/src/iptvsimple/InstanceSettings.cpp
+++ b/src/iptvsimple/InstanceSettings.cpp
@@ -63,6 +63,7 @@ void InstanceSettings::ReadSettings()
 
   // Transcoding
   m_forceTranscode = kodi::addon::GetSettingBoolean("forceTranscode", false);
+  m_forceTranscoding = kodi::addon::GetSettingBoolean("forceTranscoding", false);
   // directPlayVideoCodecs / directPlayAudioCodecs are list[string] settings —
   // GetSettingString can't read them. They arrive via SetSetting (TransferSettings
   // default case) and are captured in OnSettingChanged.

--- a/src/iptvsimple/InstanceSettings.h
+++ b/src/iptvsimple/InstanceSettings.h
@@ -86,6 +86,7 @@ namespace iptvsimple
 
     // Transcoding
     bool GetForceTranscode() const { return m_forceTranscode; }
+    bool GetForceTranscoding() const { return m_forceTranscoding; }
     const std::string& GetDirectPlayVideoCodecs() const { return m_directPlayVideoCodecs; }
     const std::string& GetDirectPlayAudioCodecs() const { return m_directPlayAudioCodecs; }
     void SetDirectPlayVideoCodecs(const std::string& v) { m_directPlayVideoCodecs = v; }
@@ -175,8 +176,9 @@ namespace iptvsimple
 
     // Transcoding
     bool m_forceTranscode = false;
+    bool m_forceTranscoding = false;
     std::string m_directPlayVideoCodecs = "h264,h264_10bit,hevc,hevc_rext,av1,mpeg2video,vp9,vc1";
-    std::string m_directPlayAudioCodecs = "aac,mp2,mp3,ac3,eac3,opus,flac";
+    std::string m_directPlayAudioCodecs = "aac,mp2,mp3,ac3,eac3,opus,flac,dts";
     int m_preferredVideoCodec = 0;  // 0=H264, 1=H265, 2=AV1
     int m_preferredAudioCodec = 0;  // 0=AAC, 1=AC3, 2=MP3, 3=Opus
     int m_maxAudioChannels = 6;

--- a/src/iptvsimple/InstanceSettings.h
+++ b/src/iptvsimple/InstanceSettings.h
@@ -133,9 +133,6 @@ namespace iptvsimple
     int GetConnectioncCheckTimeoutSecs() const { return m_connectioncCheckTimeoutSecs; }
     int GetConnectioncCheckIntervalSecs() const { return m_connectioncCheckIntervalSecs; }
 
-    bool GetSuppressCodecCapture() const { return m_suppressCodecCapture; }
-    void SetSuppressCodecCapture(bool v) { m_suppressCodecCapture = v; }
-
     // Codec name helpers for device profile
     std::string GetPreferredVideoCodecName() const
     {
@@ -208,7 +205,5 @@ namespace iptvsimple
     int m_jellyfinUpdateIntervalHours = 24;
     int m_connectioncCheckTimeoutSecs = DEFAULT_CONNECTION_CHECK_TIMEOUT_SECS;
     int m_connectioncCheckIntervalSecs = 60;
-
-    bool m_suppressCodecCapture = false;
   };
 } //namespace iptvsimple

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -410,8 +410,9 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
       addCodec(token);
   }
 
-  // Container choice: AV1 can't ride MPEG-TS so transcode-to-AV1 needs fMP4.
-  const std::string transcodeContainer = (preferredVideo == "av1") ? "mp4" : "ts";
+  // Always request TS container in the profile. PostProcessTranscodingUrl
+  // switches to fMP4 when the server is actually transcoding to AV1.
+  const std::string transcodeContainer = "ts";
 
   // inputstream.adaptive rejects single-segment transcode playlists with
   // "Codec id NN require extradata". Remux segments are instant and work
@@ -421,12 +422,9 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
   // Build video codec list for TranscodingProfile: preferred first, then
   // remaining allowed codecs. The preferred codec is always included even if
   // not in the allowed list — it's the transcode target when re-encoding.
-  // AV1 is stripped when container is TS (MPEG-TS can't carry AV1).
   std::string transcodingVideoCodecs;
   {
     auto addTranscodeCodec = [&](const std::string& codec) {
-      if (transcodeContainer == "ts" && codec == "av1")
-        return;
       if (!transcodingVideoCodecs.empty())
         transcodingVideoCodecs += ",";
       transcodingVideoCodecs += codec;
@@ -674,6 +672,35 @@ std::string JellyfinChannelLoader::PostProcessTranscodingUrl(
 
   const int maxBitrateBps = m_activeMaxBitrateBps > 0
     ? m_activeMaxBitrateBps : m_settings->GetMaxBitrateBps();
+
+  // AV1 can't ride MPEG-TS. If the server is transcoding video and AV1 is the
+  // preferred (first) codec, switch the segment container to fMP4.
+  {
+    std::string transcodeReasons;
+    std::string videoCodec;
+    for (const auto& p : params)
+    {
+      if (p.find("TranscodeReasons=") == 0)
+        transcodeReasons = p.substr(17);
+      else if (p.find("VideoCodec=") == 0)
+        videoCodec = p.substr(11);
+    }
+    bool videoTranscoded =
+        transcodeReasons.find("VideoCodecNotSupported") != std::string::npos ||
+        transcodeReasons.find("ContainerBitrateExceedsLimit") != std::string::npos ||
+        transcodeReasons.find("VideoProfileNotSupported") != std::string::npos ||
+        transcodeReasons.find("VideoLevelNotSupported") != std::string::npos ||
+        transcodeReasons.find("VideoBitDepthNotSupported") != std::string::npos ||
+        transcodeReasons.find("VideoFramerateNotSupported") != std::string::npos ||
+        transcodeReasons.find("VideoResolutionNotSupported") != std::string::npos;
+
+    if (videoTranscoded && videoCodec.substr(0, 3) == "av1")
+    {
+      for (auto& p : params)
+        if (p.find("SegmentContainer=") == 0)
+          p = "SegmentContainer=mp4";
+    }
+  }
 
   // Strip the server's VideoBitrate/AudioBitrate — we always recalculate.
   params.erase(std::remove_if(params.begin(), params.end(), [](const std::string& p) {

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -12,6 +12,7 @@
 #include "../utilities/TimeUtils.h"
 #include "../utilities/WebUtils.h"
 
+#include <kodi/Filesystem.h>
 #include <kodi/General.h>
 
 #include <algorithm>
@@ -624,18 +625,29 @@ std::string JellyfinChannelLoader::GetRecordingStreamUrl(
   Logger::Log(LEVEL_DEBUG, "%s - Recording stream URL: %s", __FUNCTION__,
               WebUtils::RedactUrl(streamUrl).c_str());
 
-  // Persist session metadata for Python playback reporter.
-  // Each SetSettingString triggers TransferSettings which re-delivers
-  // list[string] codec settings with stale values — suppress capture.
-  m_settings->SetSuppressCodecCapture(true);
-  kodi::addon::SetSettingString("sessionItemId", m_activeItemId);
-  kodi::addon::SetSettingString("sessionMediaSourceId", m_activeMediaSourceId);
-  kodi::addon::SetSettingString("sessionPlaySessionId", m_activePlaySessionId);
-  kodi::addon::SetSettingString("sessionLiveStreamId", m_activeLiveStreamId);
-  kodi::addon::SetSettingString("sessionPlayMethod", m_activePlayMethod);
-  m_settings->SetSuppressCodecCapture(false);
+  WriteSessionFile();
 
   return streamUrl;
+}
+
+void JellyfinChannelLoader::WriteSessionFile()
+{
+  const std::string path = m_settings->GetUserPath() + "session.json";
+  Json::Value session;
+  session["ItemId"] = m_activeItemId;
+  session["MediaSourceId"] = m_activeMediaSourceId;
+  session["PlaySessionId"] = m_activePlaySessionId;
+  session["LiveStreamId"] = m_activeLiveStreamId;
+  session["PlayMethod"] = m_activePlayMethod;
+  Json::StreamWriterBuilder writer;
+  writer["indentation"] = "";
+  const std::string data = Json::writeString(writer, session);
+  kodi::vfs::CFile file;
+  if (file.OpenFileForWrite(path, true))
+  {
+    file.Write(data.c_str(), data.size());
+    file.Close();
+  }
 }
 
 std::string JellyfinChannelLoader::PostProcessTranscodingUrl(
@@ -862,14 +874,7 @@ std::string JellyfinChannelLoader::GetItemStreamUrl(const std::string& itemId,
   Logger::Log(LEVEL_DEBUG, "%s - Stream URL: %s", __FUNCTION__,
               WebUtils::RedactUrl(streamUrl).c_str());
 
-  // Persist session metadata for Python playback reporter.
-  m_settings->SetSuppressCodecCapture(true);
-  kodi::addon::SetSettingString("sessionItemId", m_activeItemId);
-  kodi::addon::SetSettingString("sessionMediaSourceId", m_activeMediaSourceId);
-  kodi::addon::SetSettingString("sessionPlaySessionId", m_activePlaySessionId);
-  kodi::addon::SetSettingString("sessionLiveStreamId", m_activeLiveStreamId);
-  kodi::addon::SetSettingString("sessionPlayMethod", m_activePlayMethod);
-  m_settings->SetSuppressCodecCapture(false);
+  WriteSessionFile();
 
   return streamUrl;
 }

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -465,12 +465,22 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
   // bitrate limit. For live TV (Protocol=Http), Jellyfin ignores
   // MaxStreamingBitrate for DirectPlay decisions, so we must clear
   // DirectPlayProfiles to force TranscodingProfiles when a limit is set.
+  // DirectPlay video codecs: allowed list + preferred (if not already in it).
+  // Setting a preferred codec implies the device can decode it.
+  std::string directPlayVideoCodecs = allowedVideoCodecsCsv;
+  if (allowedVideoCodecsCsv.find(preferredVideo) == std::string::npos)
+  {
+    if (!directPlayVideoCodecs.empty())
+      directPlayVideoCodecs += ",";
+    directPlayVideoCodecs += preferredVideo;
+  }
+
   Json::Value directPlayProfiles(Json::arrayValue);
-  if (!forceRemux && !forceTranscodeActive && bitrateUnlimited && !allowedVideoCodecsCsv.empty())
+  if (!forceRemux && !forceTranscodeActive && bitrateUnlimited && !directPlayVideoCodecs.empty())
   {
     Json::Value v;
     v["Type"] = "Video";
-    v["VideoCodec"] = allowedVideoCodecsCsv;
+    v["VideoCodec"] = directPlayVideoCodecs;
     v["AudioCodec"] = audioCodecs;
     directPlayProfiles.append(v);
     Json::Value a;

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -342,7 +342,8 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
   // Per-channel overrides win over global settings; otherwise fall back.
   const int maxBitrateBps = overrides.bitrateBps.value_or(m_settings->GetMaxBitrateBps());
   const bool forceRemux = overrides.forceRemux.value_or(m_settings->GetForceTranscode());
-  const bool forceTranscodeOverride = overrides.forceTranscode.value_or(false);
+  const bool forceTranscodeActive = overrides.forceTranscode.value_or(m_settings->GetForceTranscoding());
+  const bool bitrateUnlimited = (maxBitrateBps >= 1000000000);
 
   Json::Value profile;
   profile["Name"] = "Kodi";
@@ -409,10 +410,7 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
       addCodec(token);
   }
 
-  const bool bitrateUnlimited = (maxBitrateBps >= 1000000000);
-
   // Container choice: AV1 can't ride MPEG-TS so transcode-to-AV1 needs fMP4.
-  // Remux always uses TS (AV1 is stripped from the remux codec list below).
   const std::string transcodeContainer = (preferredVideo == "av1") ? "mp4" : "ts";
 
   // inputstream.adaptive rejects single-segment transcode playlists with
@@ -420,52 +418,40 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
   // with 1; transcode needs 3 when adaptive is the inputstream.
   const bool useAdaptive = overrides.inputstream.value_or("") == "inputstream.adaptive";
 
-  // TranscodingProfiles:
-  // - Remux mode (forceRemux ON + unlimited bitrate + no per-channel forceTranscode)
-  //   → codec-copy the allowed codecs.
-  // - Otherwise → preferred codec only.
-  Json::Value transcodingProfiles(Json::arrayValue);
-
-  const bool remuxMode = forceRemux && bitrateUnlimited && !forceTranscodeOverride;
-
-  if (remuxMode)
+  // Build video codec list for TranscodingProfile: preferred first, then
+  // remaining allowed codecs. The preferred codec is always included even if
+  // not in the allowed list — it's the transcode target when re-encoding.
+  // AV1 is stripped when container is TS (MPEG-TS can't carry AV1).
+  std::string transcodingVideoCodecs;
   {
-    Json::Value tp;
-    tp["Container"] = "ts";
-    tp["Type"] = "Video";
-    tp["AudioCodec"] = audioCodecs;
-    // TS can't carry AV1; drop it from the remux codec list.
-    std::string remuxCodecs;
-    std::string::size_type rStart = 0;
-    while (rStart < allowedVideoCodecsCsv.length())
+    auto addTranscodeCodec = [&](const std::string& codec) {
+      if (transcodeContainer == "ts" && codec == "av1")
+        return;
+      if (!transcodingVideoCodecs.empty())
+        transcodingVideoCodecs += ",";
+      transcodingVideoCodecs += codec;
+    };
+    addTranscodeCodec(preferredVideo);
+    std::string::size_type vStart = 0;
+    while (vStart < allowedVideoCodecsCsv.length())
     {
-      auto rEnd = allowedVideoCodecsCsv.find(',', rStart);
-      if (rEnd == std::string::npos)
-        rEnd = allowedVideoCodecsCsv.length();
-      std::string c = allowedVideoCodecsCsv.substr(rStart, rEnd - rStart);
-      if (c != "av1")
-      {
-        if (!remuxCodecs.empty())
-          remuxCodecs += ",";
-        remuxCodecs += c;
-      }
-      rStart = rEnd + 1;
+      auto vEnd = allowedVideoCodecsCsv.find(',', vStart);
+      if (vEnd == std::string::npos)
+        vEnd = allowedVideoCodecsCsv.length();
+      std::string codec = allowedVideoCodecsCsv.substr(vStart, vEnd - vStart);
+      if (codec != preferredVideo)
+        addTranscodeCodec(codec);
+      vStart = vEnd + 1;
     }
-    tp["VideoCodec"] = remuxCodecs;
-    tp["Context"] = "Streaming";
-    tp["Protocol"] = "hls";
-    tp["MaxAudioChannels"] = std::to_string(m_settings->GetMaxAudioChannels());
-    tp["MinSegments"] = useAdaptive ? "3" : "1";
-    tp["BreakOnNonKeyFrames"] = true;
-    transcodingProfiles.append(tp);
   }
-  else
+
+  Json::Value transcodingProfiles(Json::arrayValue);
   {
     Json::Value tp;
     tp["Container"] = transcodeContainer;
     tp["Type"] = "Video";
     tp["AudioCodec"] = audioCodecs;
-    tp["VideoCodec"] = preferredVideo;
+    tp["VideoCodec"] = transcodingVideoCodecs;
     tp["Context"] = "Streaming";
     tp["Protocol"] = "hls";
     tp["MaxAudioChannels"] = std::to_string(m_settings->GetMaxAudioChannels());
@@ -480,11 +466,12 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
   // MaxStreamingBitrate for DirectPlay decisions, so we must clear
   // DirectPlayProfiles to force TranscodingProfiles when a limit is set.
   Json::Value directPlayProfiles(Json::arrayValue);
-  if (!forceRemux && !forceTranscodeOverride && bitrateUnlimited && !allowedVideoCodecsCsv.empty())
+  if (!forceRemux && !forceTranscodeActive && bitrateUnlimited && !allowedVideoCodecsCsv.empty())
   {
     Json::Value v;
     v["Type"] = "Video";
     v["VideoCodec"] = allowedVideoCodecsCsv;
+    v["AudioCodec"] = audioCodecs;
     directPlayProfiles.append(v);
     Json::Value a;
     a["Type"] = "Audio";
@@ -557,23 +544,16 @@ std::string JellyfinChannelLoader::GetRecordingStreamUrl(
   Json::Value body;
   body["UserId"] = m_client->GetUserId();
   ChannelOverrides effectiveOverrides = overrides;
-  if (inProgress && !effectiveOverrides.forceTranscode.value_or(false))
+  if (inProgress)
     effectiveOverrides.forceRemux = true;
   Json::Value deviceProfile = BuildDeviceProfile(effectiveOverrides);
   if (inProgress)
     deviceProfile["DirectPlayProfiles"] = Json::Value(Json::arrayValue);
-  // Recordings always play via inputstream.adaptive but overrides.inputstream
-  // isn't set, so BuildDeviceProfile leaves MinSegments=1 in the transcode
-  // branch. Bump it to 3 — adaptive needs a populated variant playlist.
-  // Only touch the transcode profile (single codec); leave remux (multi-codec) at 1.
+  // Recordings play via inputstream.adaptive which needs MinSegments >= 3.
   if (!deviceProfile["TranscodingProfiles"].empty())
-  {
-    Json::Value& tp = deviceProfile["TranscodingProfiles"][0];
-    const std::string vc = tp.get("VideoCodec", "").asString();
-    if (vc.find(',') == std::string::npos)
-      tp["MinSegments"] = "3";
-  }
+    deviceProfile["TranscodingProfiles"][0]["MinSegments"] = "3";
   body["DeviceProfile"] = deviceProfile;
+  m_activeMaxBitrateBps = effectiveOverrides.bitrateBps.value_or(m_settings->GetMaxBitrateBps());
   body["AutoOpenLiveStream"] = true;
 
   Json::StreamWriterBuilder writer;
@@ -591,6 +571,8 @@ std::string JellyfinChannelLoader::GetRecordingStreamUrl(
 
   const Json::Value& source = response["MediaSources"][0];
 
+  m_activeSourceBitrateBps = source.get("Bitrate", 0).asInt();
+
   // Track session state for reporting and cleanup
   m_activeLiveStreamId = source.get("LiveStreamId", "").asString();
   m_activePlaySessionId = response.get("PlaySessionId", "").asString();
@@ -607,10 +589,11 @@ std::string JellyfinChannelLoader::GetRecordingStreamUrl(
               hasTranscodingUrl ? "present" : "absent");
 
   std::string streamUrl;
+  const bool forceTranscodeActive = effectiveOverrides.forceTranscode.value_or(m_settings->GetForceTranscoding());
 
   if (hasTranscodingUrl)
   {
-    streamUrl = m_client->GetBaseUrl() + source["TranscodingUrl"].asString();
+    streamUrl = PostProcessTranscodingUrl(source["TranscodingUrl"].asString(), true, forceTranscodeActive);
   }
   else
   {
@@ -648,7 +631,7 @@ std::string JellyfinChannelLoader::GetRecordingStreamUrl(
 }
 
 std::string JellyfinChannelLoader::PostProcessTranscodingUrl(
-    const std::string& transcodingUrl, bool keepMaster, bool isRemux)
+    const std::string& transcodingUrl, bool keepMaster, bool forceTranscode)
 {
   // Post-process TranscodingUrl to match jellyfin-kodi behaviour:
   // - For ffmpegdirect/internal: replace "stream"/"master" with "live" so we
@@ -697,13 +680,12 @@ std::string JellyfinChannelLoader::PostProcessTranscodingUrl(
   }
 
   const int audioBitrate = 384000;
-  const bool bitrateUnlimited = (maxBitrateBps >= 1000000000);
   int videoBitrate;
-  if (!isRemux && bitrateUnlimited)
+  if (forceTranscode)
   {
     const int sourceBps = m_activeSourceBitrateBps > 0
       ? m_activeSourceBitrateBps : 30000000;
-    videoBitrate = sourceBps - audioBitrate;
+    videoBitrate = std::min(sourceBps, maxBitrateBps) - audioBitrate;
   }
   else
   {
@@ -805,17 +787,12 @@ std::string JellyfinChannelLoader::GetItemStreamUrl(const std::string& itemId,
 
   std::string streamUrl;
 
-  // Determine if this session is remux (codec-copy) vs real transcode.
-  const int maxBitrateBps = overrides.bitrateBps.value_or(m_settings->GetMaxBitrateBps());
-  const bool bitrateUnlimited = (maxBitrateBps >= 1000000000);
-  const bool forceRemux = overrides.forceRemux.value_or(m_settings->GetForceTranscode());
-  const bool forceTranscodeOverride = overrides.forceTranscode.value_or(false);
-  const bool isRemux = forceRemux && bitrateUnlimited && !forceTranscodeOverride;
+  const bool forceTranscodeActive = overrides.forceTranscode.value_or(m_settings->GetForceTranscoding());
 
   if (hasTranscodingUrl)
   {
     const bool keepMaster = overrides.inputstream.value_or("") == "inputstream.adaptive";
-    streamUrl = PostProcessTranscodingUrl(source["TranscodingUrl"].asString(), keepMaster, isRemux);
+    streamUrl = PostProcessTranscodingUrl(source["TranscodingUrl"].asString(), keepMaster, forceTranscodeActive);
   }
   else if (source.isMember("Path") && !source["Path"].asString().empty())
   {

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
@@ -70,7 +70,7 @@ private:
   static std::string FormatIso8601(time_t time);
   static time_t ParseIso8601(const std::string& dateStr);
   Json::Value BuildDeviceProfile(const ChannelOverrides& overrides);
-  std::string PostProcessTranscodingUrl(const std::string& transcodingUrl, bool keepMaster, bool isRemux);
+  std::string PostProcessTranscodingUrl(const std::string& transcodingUrl, bool keepMaster, bool forceTranscode);
   void RewriteLocalhost(std::string& url);
 
   // Jellyfin channel ID <-> Kodi channel UID mappings

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
@@ -71,6 +71,7 @@ private:
   static time_t ParseIso8601(const std::string& dateStr);
   Json::Value BuildDeviceProfile(const ChannelOverrides& overrides);
   std::string PostProcessTranscodingUrl(const std::string& transcodingUrl, bool keepMaster, bool forceTranscode);
+  void WriteSessionFile();
   void RewriteLocalhost(std::string& url);
 
   // Jellyfin channel ID <-> Kodi channel UID mappings


### PR DESCRIPTION
`BuildDeviceProfile()` had two separate TranscodingProfile branches — one for remux (all codecs, codec-copy) and one for transcode (preferred codec only). This didn't match how Jellyfin actually works: the server decides codec-copy vs re-encode based on the codec list and bitrate constraint, not a flag from us. The split caused problems when direct play failed for unrelated reasons (e.g. excluded audio codec) — the fallback TranscodingProfile had only the preferred video codec, unnecessarily re-encoding video.

### Changes

- **Unified TranscodingProfile** — single profile with preferred codec first, then all allowed codecs. Server codec-copies when it can, transcodes to the preferred codec when it must.
- **"Force transcoding" global setting** — caps URL bitrate at source bitrate, forcing the server to re-encode to the preferred codec. Previously only available as a per-channel M3U override (`kofin-force-transcode`).
- **Preferred video codec in DirectPlayProfiles** — setting a preferred codec implies the device can decode it, so include it in direct play profiles.
- **Simplified `PostProcessTranscodingUrl`** — replaced `isRemux` parameter with `forceTranscode`. Bitrate logic: `forceTranscode` → `min(source, max) - audio`, otherwise `max - audio`.
- **DTS added to audio codec options.**
- **Release workflow runs build matrix on PRs** for cross-platform compile verification.
- Playback reporting now uses a file instead of settings.
