### PR TITLE
Migrate auth to non-deprecated methods for Jellyfin v12

### DIFF
--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -984,7 +984,7 @@ bool IptvSimple::OpenRecordedStreamImpl(const kodi::addon::PVRRecording& recordi
     return false;
 
   const std::string streamUrl = m_jellyfinClient->GetBaseUrl()
-    + "/Videos/" + recordingId + "/stream?static=true&api_key="
+    + "/Videos/" + recordingId + "/stream?static=true&ApiKey="
     + m_jellyfinClient->GetAccessToken();
 
   Logger::Log(LEVEL_INFO, "%s - Opening recording stream for %s", __FUNCTION__, recordingId.c_str());

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -626,19 +626,17 @@ std::string JellyfinChannelLoader::GetRecordingStreamUrl(
   else
   {
     streamUrl = m_client->GetBaseUrl() + "/Videos/" + recordingId
-      + "/stream?static=true&api_key=" + m_client->GetAccessToken();
+      + "/stream?static=true&ApiKey=" + m_client->GetAccessToken();
   }
 
   RewriteLocalhost(streamUrl);
 
-  // Append api_key if it's a Jellyfin URL
   const std::string baseUrl = m_client->GetBaseUrl();
   if (streamUrl.find(baseUrl) == 0 &&
-      streamUrl.find("api_key=") == std::string::npos &&
       streamUrl.find("ApiKey=") == std::string::npos)
   {
     streamUrl += (streamUrl.find('?') != std::string::npos ? "&" : "?");
-    streamUrl += "api_key=" + m_client->GetAccessToken();
+    streamUrl += "ApiKey=" + m_client->GetAccessToken();
   }
 
   Logger::Log(LEVEL_DEBUG, "%s - Recording stream URL: %s", __FUNCTION__,
@@ -875,20 +873,18 @@ std::string JellyfinChannelLoader::GetItemStreamUrl(const std::string& itemId,
     streamUrl = m_client->GetBaseUrl() + "/Videos/" + itemId + "/live.m3u8"
       + "?LiveStreamId=" + WebUtils::UrlEncode(m_activeLiveStreamId)
       + "&MediaSourceId=" + WebUtils::UrlEncode(mediaSourceId)
-      + "&api_key=" + m_client->GetAccessToken();
+      + "&ApiKey=" + m_client->GetAccessToken();
   }
 
   // Fix localhost/127.0.0.1 references from tuner providers
   RewriteLocalhost(streamUrl);
 
-  // Only append api_key to Jellyfin server URLs, not third-party tuner URLs
   const std::string baseUrl = m_client->GetBaseUrl();
   if (streamUrl.find(baseUrl) == 0 &&
-      streamUrl.find("api_key=") == std::string::npos &&
       streamUrl.find("ApiKey=") == std::string::npos)
   {
     streamUrl += (streamUrl.find('?') != std::string::npos ? "&" : "?");
-    streamUrl += "api_key=" + m_client->GetAccessToken();
+    streamUrl += "ApiKey=" + m_client->GetAccessToken();
   }
 
   Logger::Log(LEVEL_DEBUG, "%s - Stream URL: %s", __FUNCTION__,

--- a/src/iptvsimple/jellyfin/JellyfinClient.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinClient.cpp
@@ -227,7 +227,7 @@ bool JellyfinClient::SendDelete(const std::string& endpoint)
   }
 
   file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "customrequest", "DELETE");
-  file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "X-Emby-Authorization", BuildAuthHeader());
+  file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "Authorization", BuildAuthHeader());
   file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "Content-Type", "application/json");
   file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "Connection", "close");
   file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "connection-timeout", "10");
@@ -256,7 +256,7 @@ Json::Value JellyfinClient::DoRequest(const std::string& url, const std::string&
     return result;
   }
 
-  file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "X-Emby-Authorization", BuildAuthHeader());
+  file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "Authorization", BuildAuthHeader());
   file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "Content-Type", "application/json");
   // Don't let Kodi's curl pool cache this connection. A long-running playback
   // produced dozens of idle keep-alive connections that Kodi's stop flow had


### PR DESCRIPTION
X-Emby-Authorization header → Authorization header. api_key query param → ApiKey query param.