### PR TITLE
Add disk space reporting via Jellyfin GetSystemStorage

### DIFF
--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -356,6 +356,21 @@ PVR_ERROR IptvSimple::GetConnectionString(std::string& connection)
   return PVR_ERROR_NO_ERROR;
 }
 
+PVR_ERROR IptvSimple::GetDriveSpace(uint64_t& total, uint64_t& used)
+{
+  if (!m_jellyfinClient)
+    return PVR_ERROR_SERVER_ERROR;
+
+  uint64_t totalBytes = 0;
+  uint64_t usedBytes = 0;
+  if (!m_jellyfinClient->GetStorageInfo(totalBytes, usedBytes))
+    return PVR_ERROR_NOT_IMPLEMENTED;
+
+  total = totalBytes / 1024;
+  used = usedBytes / 1024;
+  return PVR_ERROR_NO_ERROR;
+}
+
 void IptvSimple::Process()
 {
   static const int TIMER_RECORDING_POLL_SECS = 60;

--- a/src/IptvSimple.h
+++ b/src/IptvSimple.h
@@ -43,6 +43,7 @@ public:
   PVR_ERROR GetBackendName(std::string& name) override;
   PVR_ERROR GetBackendVersion(std::string& version) override;
   PVR_ERROR GetConnectionString(std::string& connection) override;
+  PVR_ERROR GetDriveSpace(uint64_t& total, uint64_t& used) override;
 
   PVR_ERROR OnSystemSleep() override;
   PVR_ERROR OnSystemWake() override;

--- a/src/iptvsimple/jellyfin/JellyfinClient.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinClient.cpp
@@ -183,6 +183,32 @@ bool JellyfinClient::FetchServerInfo(std::string& serverName)
   return true;
 }
 
+bool JellyfinClient::GetStorageInfo(uint64_t& totalBytes, uint64_t& usedBytes)
+{
+  Json::Value response = SendGet("/System/Info/Storage");
+  if (response.isNull() || !response.isMember("Libraries"))
+    return false;
+
+  totalBytes = 0;
+  usedBytes = 0;
+
+  for (const auto& lib : response["Libraries"])
+  {
+    if (lib.get("Name", "").asString() != "Recordings")
+      continue;
+    if (!lib.isMember("Folders") || lib["Folders"].empty())
+      break;
+    const Json::Value& folder = lib["Folders"][0];
+    uint64_t free = folder.get("FreeSpace", 0).asUInt64();
+    uint64_t used = folder.get("UsedSpace", 0).asUInt64();
+    totalBytes = free + used;
+    usedBytes = used;
+    return true;
+  }
+
+  return false;
+}
+
 /***************************************************************************
  * HTTP Methods
  **************************************************************************/

--- a/src/iptvsimple/jellyfin/JellyfinClient.h
+++ b/src/iptvsimple/jellyfin/JellyfinClient.h
@@ -33,6 +33,7 @@ public:
 
   // Server info
   bool FetchServerInfo(std::string& serverName);
+  bool GetStorageInfo(uint64_t& totalBytes, uint64_t& usedBytes);
 
   // HTTP methods
   Json::Value SendGet(const std::string& endpoint);


### PR DESCRIPTION
Implements GetDriveSpace using the Recordings library from /System/Info/Storage. Returns PVR_ERROR_NOT_IMPLEMENTED if the endpoint is unavailable or no Recordings library exists.

Kodi shows storage status in Settings -> System info -> PVR service