### PR TITLE
Add "Allowed HDR types" and "Maximum resolution" settings

### DIFF
--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.8.0"
+  version="0.9.0"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/changelog.txt
+++ b/pvr.kofin/changelog.txt
@@ -1,3 +1,8 @@
+v0.9.0
+- Add "Allowed HDR types" setting: choose which HDR/Dolby Vision formats pass through to your display; unselected formats are tone-mapped to SDR by the server (HEVC, AV1, VP9)
+- Add "Maximum resolution" setting: cap playback resolution; higher-resolution sources are downscaled by the server
+- TS transcoding profile leads with HEVC when AV1 is the preferred codec, so a forced transcode targets the more efficient codec
+
 v0.8.0
 - Dual TranscodingProfiles: AV1 streams use an fMP4 container and all other codecs use TS, replacing the transcoding-URL container-switch hack — the server selects the container by codec-copy compatibility
 - Jellyfin v12 compatibility: use the non-deprecated Authorization header and ApiKey query parameter (instead of X-Emby-Authorization / api_key)

--- a/pvr.kofin/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.kofin/resources/language/resource.language.en_gb/strings.po
@@ -563,3 +563,85 @@ msgstr ""
 msgctxt "#30795"
 msgid "Surround 7.1 (8)"
 msgstr ""
+
+#: Allowed HDR types (allowedHdrTypes)
+msgctxt "#30810"
+msgid "Allowed HDR types"
+msgstr ""
+
+msgctxt "#30811"
+msgid "HDR formats allowed to pass through to your display. Formats not selected are tone-mapped to SDR by the server. SDR is always allowed. No effect when Force direct play is on."
+msgstr ""
+
+msgctxt "#30812"
+msgid "HDR10"
+msgstr ""
+
+msgctxt "#30813"
+msgid "HLG"
+msgstr ""
+
+msgctxt "#30814"
+msgid "HDR10+"
+msgstr ""
+
+msgctxt "#30815"
+msgid "Dolby Vision"
+msgstr ""
+
+msgctxt "#30816"
+msgid "Dolby Vision (HDR10 fallback)"
+msgstr ""
+
+msgctxt "#30817"
+msgid "Dolby Vision (HLG fallback)"
+msgstr ""
+
+msgctxt "#30818"
+msgid "Dolby Vision (SDR fallback)"
+msgstr ""
+
+msgctxt "#30819"
+msgid "Dolby Vision Profile 7 (EL)"
+msgstr ""
+
+msgctxt "#30820"
+msgid "Dolby Vision + HDR10+"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Dolby Vision Profile 7 + HDR10+"
+msgstr ""
+
+#: Maximum resolution (maxResolution)
+msgctxt "#30822"
+msgid "Maximum resolution"
+msgstr ""
+
+msgctxt "#30823"
+msgid "Caps video by width; higher-resolution sources are downscaled by the server. No effect when Force direct play is on."
+msgstr ""
+
+msgctxt "#30824"
+msgid "480p"
+msgstr ""
+
+msgctxt "#30825"
+msgid "720p"
+msgstr ""
+
+msgctxt "#30826"
+msgid "1080p"
+msgstr ""
+
+msgctxt "#30827"
+msgid "1440p"
+msgstr ""
+
+msgctxt "#30828"
+msgid "2160p (4K)"
+msgstr ""
+
+msgctxt "#30829"
+msgid "Unlimited"
+msgstr ""

--- a/pvr.kofin/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.kofin/resources/language/resource.language.en_gb/strings.po
@@ -41,7 +41,7 @@ msgid "Preferred video codec"
 msgstr ""
 
 msgctxt "#30625"
-msgid "The video codec to request when transcoding. AV1 will not be chosen by Jellyfin for encoding unless the source codec is also AV1."
+msgid "The video codec to request when transcoding. AV1 will not be chosen by Jellyfin for encoding unless the source codec is also AV1 or the source codec is turned off for direct play."
 msgstr ""
 
 msgctxt "#30626"

--- a/pvr.kofin/resources/settings.xml
+++ b/pvr.kofin/resources/settings.xml
@@ -240,6 +240,34 @@
             </dependency>
           </dependencies>
         </setting>
+        <setting id="allowedHdrTypes" type="list[string]" label="30810" help="30811">
+          <level>0</level>
+          <default>HDR10,HLG,HDR10Plus,DOVI,DOVIWithHDR10,DOVIWithHLG,DOVIWithSDR,DOVIWithEL,DOVIWithHDR10Plus,DOVIWithELHDR10Plus</default>
+          <constraints>
+            <options>
+              <option label="30812">HDR10</option>
+              <option label="30813">HLG</option>
+              <option label="30814">HDR10Plus</option>
+              <option label="30815">DOVI</option>
+              <option label="30816">DOVIWithHDR10</option>
+              <option label="30817">DOVIWithHLG</option>
+              <option label="30818">DOVIWithSDR</option>
+              <option label="30819">DOVIWithEL</option>
+              <option label="30820">DOVIWithHDR10Plus</option>
+              <option label="30821">DOVIWithELHDR10Plus</option>
+            </options>
+            <delimiter>,</delimiter>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+            <hidevalue>true</hidevalue>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <condition operator="is" setting="forceDirectPlay">false</condition>
+            </dependency>
+          </dependencies>
+        </setting>
         <setting id="preferredVideoCodec" type="integer" label="30624" help="30625">
           <level>0</level>
           <default>0</default>
@@ -313,6 +341,26 @@
               <option label="30649">13</option>
               <option label="30650">14</option>
               <option label="30651">15</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="visible">
+              <condition operator="is" setting="forceDirectPlay">false</condition>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="maxResolution" type="integer" label="30822" help="30823">
+          <level>0</level>
+          <default>5</default>
+          <constraints>
+            <options>
+              <option label="30824">0</option>
+              <option label="30825">1</option>
+              <option label="30826">2</option>
+              <option label="30827">3</option>
+              <option label="30828">4</option>
+              <option label="30829">5</option>
             </options>
           </constraints>
           <control type="spinner" format="string" />

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -974,12 +974,15 @@ void IptvSimple::OnSettingChanged(const std::string& settingName, const kodi::ad
 
   // list[string] settings can't be read by GetSettingString — capture them
   // here where TransferSettings delivers the value as a plain string.
-  if (settingName == "directPlayVideoCodecs" || settingName == "directPlayAudioCodecs")
+  if (settingName == "directPlayVideoCodecs" || settingName == "directPlayAudioCodecs" ||
+      settingName == "allowedHdrTypes")
   {
     if (settingName == "directPlayVideoCodecs")
       m_settings->SetDirectPlayVideoCodecs(settingValue.GetString());
-    else
+    else if (settingName == "directPlayAudioCodecs")
       m_settings->SetDirectPlayAudioCodecs(settingValue.GetString());
+    else
+      m_settings->SetAllowedHdrTypes(settingValue.GetString());
     return;
   }
 

--- a/src/iptvsimple/InstanceSettings.cpp
+++ b/src/iptvsimple/InstanceSettings.cpp
@@ -65,13 +65,14 @@ void InstanceSettings::ReadSettings()
   m_forceTranscode = kodi::addon::GetSettingBoolean("forceTranscode", false);
   m_forceTranscoding = kodi::addon::GetSettingBoolean("forceTranscoding", false);
   m_forceDirectPlay = kodi::addon::GetSettingBoolean("forceDirectPlay", false);
-  // directPlayVideoCodecs / directPlayAudioCodecs are list[string] settings —
-  // GetSettingString can't read them. They arrive via SetSetting (TransferSettings
-  // default case) and are captured in OnSettingChanged.
+  // directPlayVideoCodecs / directPlayAudioCodecs / allowedHdrTypes are list[string]
+  // settings — GetSettingString can't read them. They arrive via SetSetting
+  // (TransferSettings default case) and are captured in OnSettingChanged.
   m_preferredVideoCodec = kodi::addon::GetSettingInt("preferredVideoCodec", 0);
   m_preferredAudioCodec = kodi::addon::GetSettingInt("preferredAudioCodec", 0);
   m_maxAudioChannels = kodi::addon::GetSettingInt("maxAudioChannels", 6);
   m_maxStreamingBitrate = kodi::addon::GetSettingInt("maxStreamingBitrate", 15);
+  m_maxResolution = kodi::addon::GetSettingInt("maxResolution", 5);
 
   // Input stream
   m_inputStream = kodi::addon::GetSettingInt("inputStream", 0);

--- a/src/iptvsimple/InstanceSettings.h
+++ b/src/iptvsimple/InstanceSettings.h
@@ -23,6 +23,10 @@ namespace iptvsimple
   };
   static const int BITRATE_TABLE_SIZE = 16;
 
+  // Max-resolution table: index -> max width px (matches settings.xml options 0-5)
+  static const int MAX_WIDTH_TABLE[] = { 854, 1280, 1920, 2560, 3840, 0 }; // 0 = unlimited
+  static const int MAX_WIDTH_TABLE_SIZE = 6;
+
   class InstanceSettings
   {
   public:
@@ -92,6 +96,8 @@ namespace iptvsimple
     const std::string& GetDirectPlayAudioCodecs() const { return m_directPlayAudioCodecs; }
     void SetDirectPlayVideoCodecs(const std::string& v) { m_directPlayVideoCodecs = v; }
     void SetDirectPlayAudioCodecs(const std::string& v) { m_directPlayAudioCodecs = v; }
+    const std::string& GetAllowedHdrTypes() const { return m_allowedHdrTypes; }
+    void SetAllowedHdrTypes(const std::string& v) { m_allowedHdrTypes = v; }
     int GetPreferredVideoCodec() const { return m_preferredVideoCodec; }
     int GetPreferredAudioCodec() const { return m_preferredAudioCodec; }
     int GetMaxAudioChannels() const { return m_maxAudioChannels; }
@@ -105,6 +111,13 @@ namespace iptvsimple
     {
       int kbps = GetMaxStreamingBitrateKbps();
       return (kbps > 0) ? kbps * 1000 : 1000000000;
+    }
+    // Max video width in px (0 = unlimited). Resolution is capped by width only.
+    int GetMaxWidth() const
+    {
+      if (m_maxResolution >= 0 && m_maxResolution < MAX_WIDTH_TABLE_SIZE)
+        return MAX_WIDTH_TABLE[m_maxResolution];
+      return 0; // unlimited
     }
 
     // Input stream: 0 = ffmpegdirect, 1 = adaptive, 2 = kodi internal
@@ -178,10 +191,12 @@ namespace iptvsimple
     bool m_forceDirectPlay = false;
     std::string m_directPlayVideoCodecs = "h264,h264_10bit,hevc,hevc_rext,av1,mpeg2video,vp9,vc1";
     std::string m_directPlayAudioCodecs = "aac,mp2,mp3,ac3,eac3,opus,flac,dts";
+    std::string m_allowedHdrTypes = "HDR10,HLG,HDR10Plus,DOVI,DOVIWithHDR10,DOVIWithHLG,DOVIWithSDR,DOVIWithEL,DOVIWithHDR10Plus,DOVIWithELHDR10Plus";
     int m_preferredVideoCodec = 0;  // 0=H264, 1=H265, 2=AV1
     int m_preferredAudioCodec = 0;  // 0=AAC, 1=AC3, 2=MP3, 3=Opus
     int m_maxAudioChannels = 6;
     int m_maxStreamingBitrate = 15; // index into BITRATE_TABLE (15=unlimited)
+    int m_maxResolution = 5;        // index into MAX_WIDTH_TABLE (5=unlimited)
 
     // Input stream
     int m_inputStream = 0;  // 0=ffmpegdirect, 1=adaptive, 2=kodi internal

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -558,6 +558,90 @@ Json::Value JellyfinChannelLoader::BuildDeviceProfile(const ChannelOverrides& ov
     cp["Conditions"].append(cond);
     codecProfiles.append(cp);
   }
+
+  // HDR: advertise which VideoRangeTypes the display accepts, per codec. The
+  // server tone-maps/transcodes formats the user didn't select; SDR is always
+  // allowed. These are separate CodecProfiles (Jellyfin ANDs them with the
+  // bit-depth/profile ones above). When every type is selected (the default),
+  // nothing is emitted — identical to prior behavior.
+  if (!forceDirectPlay)
+  {
+    static const std::set<std::string> kAllHdr = {
+      "HDR10", "HLG", "HDR10Plus", "DOVI", "DOVIWithHDR10", "DOVIWithHLG",
+      "DOVIWithSDR", "DOVIWithEL", "DOVIWithHDR10Plus", "DOVIWithELHDR10Plus"};
+    static const std::set<std::string> kVp9Hdr = {"HDR10", "HLG", "HDR10Plus"};
+
+    // Parse the selection CSV, keeping only known tokens.
+    std::set<std::string> hdrSel;
+    {
+      const std::string& raw = m_settings->GetAllowedHdrTypes();
+      std::string::size_type s = 0;
+      while (s < raw.length())
+      {
+        auto e = raw.find(',', s);
+        if (e == std::string::npos)
+          e = raw.length();
+        std::string tok = raw.substr(s, e - s);
+        if (kAllHdr.count(tok))
+          hdrSel.insert(tok);
+        s = e + 1;
+      }
+    }
+
+    // hevc and av1 share the full capability set: av1 has no Profile-7
+    // enhancement layer, but the EL tokens are harmless (no av1 source ever
+    // classifies as EL). vp9 carries no Dolby Vision.
+    auto emitHdr = [&](const char* codec, const std::set<std::string>& cap,
+                       bool canDovi, bool present) {
+      if (!present)
+        return;
+      // Only restrict when the user deselected something this codec can carry.
+      bool restricts = false;
+      for (const auto& t : cap)
+        if (!hdrSel.count(t)) { restricts = true; break; }
+      if (!restricts)
+        return;
+      std::string value = "SDR"; // always allowed; must lead the list
+      for (const auto& t : kAllHdr) // iterate canonical set for deterministic order
+        if (cap.count(t) && hdrSel.count(t))
+          value += "|" + t;
+      if (canDovi && hdrSel.count("HDR10"))
+        value += "|DOVIInvalid"; // invalid DV is served as its HDR10 base layer
+      Json::Value cp;
+      cp["Type"] = "Video";
+      cp["Codec"] = codec;
+      Json::Value cond;
+      cond["Condition"] = "EqualsAny";
+      cond["Property"] = "VideoRangeType";
+      cond["Value"] = value;
+      cond["IsRequired"] = false;
+      cp["Conditions"] = Json::Value(Json::arrayValue);
+      cp["Conditions"].append(cond);
+      codecProfiles.append(cp);
+    };
+
+    emitHdr("hevc", kAllHdr, true, hevcAllowed || hevcRextAllowed);
+    emitHdr("av1", kAllHdr, true, videoTokens.count("av1") > 0);
+    emitHdr("vp9", kVp9Hdr, false, videoTokens.count("vp9") > 0);
+  }
+
+  // Maximum resolution: cap by width (Jellyfin uses width only). A codec-less
+  // Video CodecProfile applies to all video codecs; wider sources are
+  // downscaled by the server. Unlimited (0) or force-direct-play emits nothing.
+  const int maxWidth = forceDirectPlay ? 0 : m_settings->GetMaxWidth();
+  if (maxWidth > 0)
+  {
+    Json::Value cp;
+    cp["Type"] = "Video";
+    Json::Value cond;
+    cond["Condition"] = "LessThanEqual";
+    cond["Property"] = "Width";
+    cond["Value"] = std::to_string(maxWidth);
+    cond["IsRequired"] = false;
+    cp["Conditions"] = Json::Value(Json::arrayValue);
+    cp["Conditions"].append(cond);
+    codecProfiles.append(cp);
+  }
   profile["CodecProfiles"] = codecProfiles;
 
   // Subtitle profiles


### PR DESCRIPTION
Both communicate display/network limits to Jellyfin via CodecProfiles.

- Allowed HDR types: a per-variant multiselect (HDR10/HLG/HDR10+/Dolby Vision family). Selected formats are advertised as per-codec VideoRangeType EqualsAny conditions (hevc/av1/vp9); unselected formats are tone-mapped to SDR by the server. SDR always leads; DOVIInvalid rides with HDR10 (hevc/av1); vp9 carries no Dolby Vision.
- Maximum resolution: a width cap via a codec-less Width LessThanEqual CodecProfile; wider sources are downscaled, in-spec sources still direct-play.

Both default to no limit (all HDR types selected, resolution unlimited), emitting no new CodecProfiles -- identical to prior behavior -- and skip under Force direct play.