### PR TITLE
Derive catchup MIME/manifest type from URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Install via the [Kontell Repository](https://github.com/kontell/repository.konte
 - Kofin settings can be accessed from: Settings -> PVR & Live TV -> General -> Client specific settings
 
 ## Catchup
-If supported by your provider catchup works with direct play only. Force remuxing must be disabled, InputStream must be set to FFmpeg Direct, and streams must be within any bitrate limit set. To use it you must upload a reference playlist that provides the relevant catchup tags which are omitted by Jellyfin. Refer to IPTV Simple Client for detailed catchup documentation.
+If supported by your provider catchup works with direct play only. Force remuxing must be disabled, InputStream must be set to FFmpeg Direct and bitrate must be set unlimited. To use it you must upload a reference playlist that provides the relevant catchup tags which are omitted by Jellyfin. Refer to IPTV Simple Client for detailed catchup documentation.
 
 ## Reference Playlist
 

--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.9.0"
+  version="0.9.1"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/changelog.txt
+++ b/pvr.kofin/changelog.txt
@@ -1,3 +1,6 @@
+v0.9.1
+- Fix catchup playback for TS-based sources (Xtream Codes, Flussonic mpegts, shift/append on a .ts stream): MIME and manifest type are now derived from the resolved catchup URL instead of always being labelled HLS, so inputstream.ffmpegdirect no longer fails trying to parse raw MPEG-TS as a playlist
+
 v0.9.0
 - Add "Allowed HDR types" setting: choose which HDR/Dolby Vision formats pass through to your display; unselected formats are tone-mapped to SDR by the server (HEVC, AV1, VP9)
 - Add "Maximum resolution" setting: cap playback resolution; higher-resolution sources are downscaled by the server

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -26,6 +26,33 @@ using namespace iptvsimple::data;
 using namespace iptvsimple::utilities;
 using namespace kodi::tools;
 
+namespace
+{
+
+// Append the stream URL, MIME type, inputstream and manifest_type for a catchup
+// stream played via inputstream.ffmpegdirect. MIME and manifest_type are derived
+// from the resolved catchup URL (and the channel's catchup-TS flag) rather than
+// assuming HLS: TS catchup sources — Xtream-codes, Flussonic "mpegts", and
+// shift/append on a .ts base — must NOT be labelled HLS, or ffmpegdirect tries to
+// parse raw MPEG-TS as an HLS playlist and fails. GetMimeType()/GetManifestType()
+// return "" for TS/unknown types, matching pvr.iptvsimple's SetAllStreamProperties.
+void AppendFfmpegDirectCatchupProperties(std::vector<kodi::addon::PVRStreamProperty>& properties,
+                                         const std::string& streamURL, bool isCatchupTSStream)
+{
+  const StreamType streamType = StreamUtils::GetStreamType(streamURL, "", isCatchupTSStream);
+  const std::string mimeType = StreamUtils::GetMimeType(streamType);
+  const std::string manifestType = StreamUtils::GetManifestType(streamType);
+
+  properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamURL);
+  if (!mimeType.empty())
+    properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, mimeType);
+  properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.ffmpegdirect");
+  if (!manifestType.empty())
+    properties.emplace_back("inputstream.ffmpegdirect.manifest_type", manifestType);
+}
+
+} // unnamed namespace
+
 IptvSimple::IptvSimple(const kodi::addon::IInstanceInfo& instance) : iptvsimple::IConnectionListener(instance), m_settings(new InstanceSettings())
 {
   m_channels.Clear();
@@ -392,12 +419,11 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
       else
         streamURL = m_catchupController->ProcessStreamUrl(m_currentChannel);
 
-      // Update the stream URL property (was set to raw tuner URL earlier)
+      // Update the stream URL property (was set to raw tuner URL earlier).
+      // Derive MIME + manifest_type from the resolved catchup URL so TS catchup
+      // sources aren't mislabelled as HLS (see AppendFfmpegDirectCatchupProperties).
       properties.clear();
-      properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, streamURL);
-      properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, "application/vnd.apple.mpegurl");
-      properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.ffmpegdirect");
-      properties.emplace_back("inputstream.ffmpegdirect.manifest_type", "hls");
+      AppendFfmpegDirectCatchupProperties(properties, streamURL, m_currentChannel.IsCatchupTSStream());
 
       for (const auto& prop : catchupProperties)
         properties.emplace_back(prop.first, prop.second);
@@ -646,10 +672,9 @@ PVR_ERROR IptvSimple::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& ta
   const std::string catchupUrl = m_catchupController->GetCatchupUrl(channel);
   if (!catchupUrl.empty())
   {
-    properties.emplace_back(PVR_STREAM_PROPERTY_STREAMURL, catchupUrl);
-    properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, "application/vnd.apple.mpegurl");
-    properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.ffmpegdirect");
-    properties.emplace_back("inputstream.ffmpegdirect.manifest_type", "hls");
+    // Derive MIME + manifest_type from the resolved catchup URL so TS catchup
+    // sources aren't mislabelled as HLS (see AppendFfmpegDirectCatchupProperties).
+    AppendFfmpegDirectCatchupProperties(properties, catchupUrl, channel.IsCatchupTSStream());
 
     for (const auto& prop : catchupProperties)
       properties.emplace_back(prop.first, prop.second);


### PR DESCRIPTION
Both catchup stream-property paths (GetChannelStreamProperties live timeshift, GetEPGTagStreamProperties) hardcoded manifest_type=hls and the HLS MIME type, bypassing the stream-type detection inherited from pvr.iptvsimple. TS catchup sources (Xtream Codes, Flussonic mpegts, shift/append on a .ts base) were handed to inputstream.ffmpegdirect as HLS, which fails to parse raw MPEG-TS as a playlist.

Derive MIME + manifest_type from the resolved catchup URL via StreamUtils (GetManifestType returns "" for TS, leaving it unset), matching the parent addon's SetAllStreamProperties behaviour. HLS catchup is unchanged.