### PR TITLE
Channel-loader thread-safety + reload-interval clamp

### DIFF
--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.9.0"
+  version="0.9.2"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/changelog.txt
+++ b/pvr.kofin/changelog.txt
@@ -1,3 +1,7 @@
+v0.9.2
+- Fix a potential crash from a data race on the Jellyfin channel/EPG lookup maps when a background channel/EPG reload coincided with browsing the guide or starting playback (map access is now synchronised)
+- Clamp the channel update interval to a minimum of 1 hour so a 0 value can't trigger a continuous reload loop
+
 v0.9.0
 - Add "Allowed HDR types" setting: choose which HDR/Dolby Vision formats pass through to your display; unselected formats are tone-mapped to SDR by the server (HEVC, AV1, VP9)
 - Add "Maximum resolution" setting: cap playback resolution; higher-resolution sources are downscaled by the server

--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -14,6 +14,7 @@
 #include "iptvsimple/utilities/TimeUtils.h"
 #include "iptvsimple/utilities/WebUtils.h"
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <memory>
@@ -213,7 +214,10 @@ void IptvSimple::Process()
     refreshTimer += elapsed;
     timerRecordingPollTimer += elapsed;
 
-    if (refreshTimer >= static_cast<unsigned int>(m_settings->GetJellyfinUpdateIntervalHours() * 3600))
+    // Clamp to a minimum of 1 hour: the settings control has no minimum, so a
+    // 0 or negative interval would make this always true and reload every loop.
+    const int updateIntervalHours = std::max(1, m_settings->GetJellyfinUpdateIntervalHours());
+    if (refreshTimer >= static_cast<unsigned int>(updateIntervalHours * 3600))
       m_reloadChannelsGroupsAndEPG = true;
 
     // Poll timers/recordings every 60s so Kodi learns about new/changed
@@ -321,7 +325,7 @@ PVR_ERROR IptvSimple::GetChannelStreamProperties(const kodi::addon::PVRChannel& 
     std::string streamURL;
     if (m_channelLoader)
     {
-      const std::string& jellyfinId = m_channelLoader->GetJellyfinId(m_currentChannel.GetUniqueId());
+      const std::string jellyfinId = m_channelLoader->GetJellyfinId(m_currentChannel.GetUniqueId());
       if (!jellyfinId.empty())
         streamURL = m_channelLoader->GetLiveStreamUrl(jellyfinId, overrides);
     }
@@ -609,7 +613,7 @@ PVR_ERROR IptvSimple::GetEPGTagStreamProperties(const kodi::addon::PVREPGTag& ta
   std::string streamURL;
   if (m_channelLoader)
   {
-    const std::string& jellyfinId = m_channelLoader->GetJellyfinId(channel.GetUniqueId());
+    const std::string jellyfinId = m_channelLoader->GetJellyfinId(channel.GetUniqueId());
     if (!jellyfinId.empty())
       streamURL = m_channelLoader->GetLiveStreamUrl(jellyfinId, epgOverrides);
   }

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.cpp
@@ -137,6 +137,11 @@ bool JellyfinChannelLoader::LoadChannels(Channels& channels, ChannelGroups& chan
   int channelNumber = 1;
   int matchedCount = 0;
 
+  // Build the lookup maps into locals, then swap them in under m_dataMutex at
+  // the end, so readers on other threads never observe a half-rebuilt map.
+  std::map<std::string, int> jellyfinIdToUid;
+  std::map<int, std::string> uidToJellyfinId;
+
   for (const auto& item : items)
   {
     const std::string jellyfinId = item["Id"].asString();
@@ -225,12 +230,18 @@ bool JellyfinChannelLoader::LoadChannels(Channels& channels, ChannelGroups& chan
     if (channels.AddChannel(channel, groupIdList, channelGroups, true))
     {
       int uid = channel.GetUniqueId();
-      m_jellyfinIdToUid[jellyfinId] = uid;
-      m_uidToJellyfinId[uid] = jellyfinId;
+      jellyfinIdToUid[jellyfinId] = uid;
+      uidToJellyfinId[uid] = jellyfinId;
 
       Logger::Log(LEVEL_DEBUG, "%s - Added channel '%s' (uid=%d, jellyfinId=%s, groups=%zu)",
                   __FUNCTION__, name.c_str(), uid, jellyfinId.c_str(), groupIdList.size());
     }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(m_dataMutex);
+    m_jellyfinIdToUid = std::move(jellyfinIdToUid);
+    m_uidToJellyfinId = std::move(uidToJellyfinId);
   }
 
   channelGroups.RemoveEmptyGroups();
@@ -244,14 +255,17 @@ bool JellyfinChannelLoader::LoadChannels(Channels& channels, ChannelGroups& chan
 PVR_ERROR JellyfinChannelLoader::LoadEpg(int channelUid, time_t start, time_t end,
                                           kodi::addon::PVREPGTagsResultSet& results)
 {
-  auto it = m_uidToJellyfinId.find(channelUid);
-  if (it == m_uidToJellyfinId.end())
+  std::string jellyfinId;
   {
-    Logger::Log(LEVEL_ERROR, "%s - No Jellyfin ID for channel UID %d", __FUNCTION__, channelUid);
-    return PVR_ERROR_INVALID_PARAMETERS;
+    std::lock_guard<std::mutex> lock(m_dataMutex);
+    auto it = m_uidToJellyfinId.find(channelUid);
+    if (it == m_uidToJellyfinId.end())
+    {
+      Logger::Log(LEVEL_ERROR, "%s - No Jellyfin ID for channel UID %d", __FUNCTION__, channelUid);
+      return PVR_ERROR_INVALID_PARAMETERS;
+    }
+    jellyfinId = it->second;
   }
-
-  const std::string& jellyfinId = it->second;
 
   // Use MaxStartDate (not MaxEndDate) - Jellyfin API returns programmes that start before this time
   const std::string endpoint = "/LiveTv/Programs?ChannelIds=" + jellyfinId
@@ -279,7 +293,10 @@ PVR_ERROR JellyfinChannelLoader::LoadEpg(int channelUid, time_t start, time_t en
 
     const std::string jellyfinProgramId = item["Id"].asString();
     const unsigned int broadcastUid = static_cast<unsigned int>(GenerateUid(jellyfinProgramId));
-    m_epgUidToJellyfinProgramId[broadcastUid] = jellyfinProgramId;
+    {
+      std::lock_guard<std::mutex> lock(m_dataMutex);
+      m_epgUidToJellyfinProgramId[broadcastUid] = jellyfinProgramId;
+    }
 
     tag.SetUniqueBroadcastId(broadcastUid);
     tag.SetUniqueChannelId(static_cast<unsigned int>(channelUid));
@@ -995,26 +1012,27 @@ void JellyfinChannelLoader::CloseLiveStream()
 }
 
 
-const std::string& JellyfinChannelLoader::GetJellyfinId(int channelUid) const
+std::string JellyfinChannelLoader::GetJellyfinId(int channelUid) const
 {
-  static const std::string empty;
+  std::lock_guard<std::mutex> lock(m_dataMutex);
   auto it = m_uidToJellyfinId.find(channelUid);
   if (it != m_uidToJellyfinId.end())
     return it->second;
-  return empty;
+  return {};
 }
 
-const std::string& JellyfinChannelLoader::GetJellyfinProgramId(unsigned int epgBroadcastUid) const
+std::string JellyfinChannelLoader::GetJellyfinProgramId(unsigned int epgBroadcastUid) const
 {
-  static const std::string empty;
+  std::lock_guard<std::mutex> lock(m_dataMutex);
   auto it = m_epgUidToJellyfinProgramId.find(epgBroadcastUid);
   if (it != m_epgUidToJellyfinProgramId.end())
     return it->second;
-  return empty;
+  return {};
 }
 
 int JellyfinChannelLoader::GetChannelUid(const std::string& jellyfinId) const
 {
+  std::lock_guard<std::mutex> lock(m_dataMutex);
   auto it = m_jellyfinIdToUid.find(jellyfinId);
   if (it != m_jellyfinIdToUid.end())
     return it->second;

--- a/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
+++ b/src/iptvsimple/jellyfin/JellyfinChannelLoader.h
@@ -14,6 +14,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -62,8 +63,11 @@ public:
 
   void SetClient(std::shared_ptr<JellyfinClient> client) { m_client = client; }
 
-  const std::string& GetJellyfinId(int channelUid) const;
-  const std::string& GetJellyfinProgramId(unsigned int epgBroadcastUid) const;
+  // Return by value (not const ref): callers may hold the result across a
+  // subsequent network call, during which the worker thread can rebuild the
+  // backing map. A reference would dangle; a copy is safe.
+  std::string GetJellyfinId(int channelUid) const;
+  std::string GetJellyfinProgramId(unsigned int epgBroadcastUid) const;
   int GetChannelUid(const std::string& jellyfinId) const;
 
 private:
@@ -74,6 +78,13 @@ private:
   std::string PostProcessTranscodingUrl(const std::string& transcodingUrl, bool keepMaster, bool forceTranscode);
   void WriteSessionFile();
   void RewriteLocalhost(std::string& url);
+
+  // Guards the three lookup maps below. They are rebuilt on the worker thread
+  // (LoadChannels, via Process()/ConnectionEstablished) and read/written from
+  // Kodi's PVR-callback threads (LoadEpg, GetJellyfinId, GetJellyfinProgramId,
+  // GetChannelUid), so every access must be serialised. Held only around map
+  // operations — never across the HTTP calls in LoadChannels/LoadEpg.
+  mutable std::mutex m_dataMutex;
 
   // Jellyfin channel ID <-> Kodi channel UID mappings
   std::map<std::string, int> m_jellyfinIdToUid;

--- a/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
@@ -147,7 +147,7 @@ PVR_ERROR JellyfinRecordingManager::AddTimer(const kodi::addon::PVRTimer& timer)
       Logger::Log(LEVEL_INFO, "%s - EPG map miss for UID %d, querying Jellyfin by channel+time",
                   __FUNCTION__, timer.GetEPGUid());
 
-      const std::string& channelJfId = m_channelLoader->GetJellyfinId(timer.GetClientChannelUid());
+      const std::string channelJfId = m_channelLoader->GetJellyfinId(timer.GetClientChannelUid());
       if (!channelJfId.empty())
       {
         // Query programs in a 1-minute window around the start time
@@ -212,7 +212,7 @@ PVR_ERROR JellyfinRecordingManager::AddTimer(const kodi::addon::PVRTimer& timer)
       Logger::Log(LEVEL_INFO, "%s - Series timer EPG map miss for UID %d, querying by channel+time",
                   __FUNCTION__, timer.GetEPGUid());
 
-      const std::string& channelJfId = m_channelLoader->GetJellyfinId(timer.GetClientChannelUid());
+      const std::string channelJfId = m_channelLoader->GetJellyfinId(timer.GetClientChannelUid());
       if (!channelJfId.empty())
       {
         const std::string startIso = FormatIso8601(timer.GetStartTime());
@@ -288,7 +288,7 @@ PVR_ERROR JellyfinRecordingManager::AddTimer(const kodi::addon::PVRTimer& timer)
   {
     // Manual recording — channel + time range, no EPG program ID.
     // Get timer defaults (without programId) and fill in from Kodi's timer.
-    const std::string& channelJfId = m_channelLoader->GetJellyfinId(timer.GetClientChannelUid());
+    const std::string channelJfId = m_channelLoader->GetJellyfinId(timer.GetClientChannelUid());
     if (channelJfId.empty())
     {
       Logger::Log(LEVEL_ERROR, "%s - No Jellyfin channel ID for channel UID %d",


### PR DESCRIPTION
The channel/EPG/program-id lookup maps in JellyfinChannelLoader were read from Kodi's PVR-callback threads (GetJellyfinId/GetJellyfinProgramId/ GetChannelUid, LoadEpg) while the worker thread rebuilt them in LoadChannels (Process/ConnectionEstablished), with no synchronisation. The parent pvr.iptvsimple serialised the equivalent EPG lookups under m_mutex in GetEPGForChannel; the fork dropped that lock, leaving a data race on std::map that can corrupt state or crash when a reload coincides with guide browsing or playback start.

Add a loader-internal m_dataMutex guarding the three maps, held only around map operations and never across the HTTP calls in LoadChannels/LoadEpg. LoadChannels builds the maps into locals and swaps them in atomically. GetJellyfinId/GetJellyfinProgramId now return by value so a caller can't hold a reference into a map the worker thread is rebuilding.

Also clamp the Process() reload interval to a minimum of 1 hour: the settings control has no minimum, so 0 would make the condition always true and trigger a full channel reload every loop iteration.