### PR TITLE
Start in-progress recordings from the beginning, not ~30s in

### DIFF
--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.9.2"
+  version="0.9.3"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/changelog.txt
+++ b/pvr.kofin/changelog.txt
@@ -1,3 +1,6 @@
+v0.9.3
+- Play in-progress recordings from the beginning instead of starting roughly 30 seconds in (the still-transcoding stream was being treated as live, so playback began near the playlist head rather than at the start)
+
 v0.9.2
 - Fix a potential crash from a data race on the Jellyfin channel/EPG lookup maps when a background channel/EPG reload coincided with browsing the guide or starting playback (map access is now synchronised)
 - Clamp the channel update interval to a minimum of 1 hour so a 0 value can't trigger a continuous reload loop

--- a/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
@@ -592,6 +592,12 @@ PVR_ERROR JellyfinRecordingManager::GetRecordingStreamProperties(
     properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.adaptive");
     properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, "application/vnd.apple.mpegurl");
     properties.emplace_back("inputstream.adaptive.manifest_type", "hls");
+    // Jellyfin serves an in-progress recording as an EVENT/no-ENDLIST HLS playlist,
+    // which inputstream.adaptive classifies as "live" and starts ~16s (its live-delay
+    // floor) behind the playlist head. Because the transcode has only published a few
+    // segments when the playlist is first read, that lands ~30s into the recording
+    // instead of at the start. play_timeshift_buffer makes it begin at segment 0.
+    properties.emplace_back("inputstream.adaptive.play_timeshift_buffer", "true");
   }
 
   return PVR_ERROR_NO_ERROR;

--- a/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
@@ -592,11 +592,6 @@ PVR_ERROR JellyfinRecordingManager::GetRecordingStreamProperties(
     properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.adaptive");
     properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, "application/vnd.apple.mpegurl");
     properties.emplace_back("inputstream.adaptive.manifest_type", "hls");
-    // Jellyfin serves an in-progress recording as an EVENT/no-ENDLIST HLS playlist,
-    // which inputstream.adaptive classifies as "live" and starts ~16s (its live-delay
-    // floor) behind the playlist head. Because the transcode has only published a few
-    // segments when the playlist is first read, that lands ~30s into the recording
-    // instead of at the start. play_timeshift_buffer makes it begin at segment 0.
     properties.emplace_back("inputstream.adaptive.play_timeshift_buffer", "true");
   }
 


### PR DESCRIPTION
Jellyfin serves an in-progress Live TV recording as an EVENT HLS playlist with no #EXT-X-ENDLIST, which inputstream.adaptive classifies as live. For a live stream it begins ~16s (its hard-floored live-delay) behind the playlist head; since the transcode has only published a handful of segments when the playlist is first read, playback started ~30s into the recording instead of at 0:00.

Set inputstream.adaptive.play_timeshift_buffer=true on the in-progress recording stream properties so the player starts from the first segment.