### PR TITLE
Move recorded-stream byte path into JellyfinRecordingManager

### DIFF
--- a/src/IptvSimple.cpp
+++ b/src/IptvSimple.cpp
@@ -891,84 +891,24 @@ PVR_ERROR IptvSimple::GetRecordingLastPlayedPosition(const kodi::addon::PVRRecor
  * It goes directly to OpenRecordedStream / ReadRecordedStream.
  **************************************************************************/
 
-bool IptvSimple::OpenRecordedStreamImpl(const kodi::addon::PVRRecording& recording)
-{
-  CloseRecordedStreamImpl();
-
-  const std::string recordingId = recording.GetRecordingId();
-  if (!m_jellyfinClient)
-    return false;
-
-  const std::string streamUrl = m_jellyfinClient->GetBaseUrl()
-    + "/Videos/" + recordingId + "/stream?static=true&ApiKey="
-    + m_jellyfinClient->GetAccessToken();
-
-  Logger::Log(LEVEL_INFO, "%s - Opening recording stream for %s", __FUNCTION__, recordingId.c_str());
-
-  if (!m_recordingStream.OpenFile(streamUrl, ADDON_READ_NO_CACHE))
-  {
-    Logger::Log(LEVEL_ERROR, "%s - Failed to open recording stream: %s", __FUNCTION__, recordingId.c_str());
-    return false;
-  }
-
-  m_recordingStreamOpen = true;
-  Logger::Log(LEVEL_INFO, "%s - Recording stream open, length: %lld",
-              __FUNCTION__, static_cast<long long>(m_recordingStream.GetLength()));
-  return true;
-}
-
-void IptvSimple::CloseRecordedStreamImpl()
-{
-  if (m_recordingStreamOpen)
-  {
-    Logger::Log(LEVEL_INFO, "%s - Closing recording stream", __FUNCTION__);
-    m_recordingStream.Close();
-    m_recordingStreamOpen = false;
-  }
-}
-
-int IptvSimple::ReadRecordedStreamImpl(unsigned char* buffer, unsigned int size)
-{
-  if (!m_recordingStreamOpen)
-    return -1;
-
-  ssize_t bytesRead = m_recordingStream.Read(buffer, size);
-  return static_cast<int>(bytesRead);
-}
-
-int64_t IptvSimple::SeekRecordedStreamImpl(int64_t position, int whence)
-{
-  if (!m_recordingStreamOpen)
-    return -1;
-
-  return m_recordingStream.Seek(position, whence);
-}
-
-int64_t IptvSimple::LengthRecordedStreamImpl()
-{
-  if (!m_recordingStreamOpen)
-    return -1;
-
-  return m_recordingStream.GetLength();
-}
-
-// Kodi v22 (PVR API 9.x) adds streamId parameter to all recording stream methods
+// The byte-stream itself lives in JellyfinRecordingManager; these overrides
+// just adapt the Kodi v21/v22 signatures (v22 adds a streamId) and delegate.
 #ifdef KODI_PVR_API_V9
 bool IptvSimple::OpenRecordedStream(const kodi::addon::PVRRecording& recording, int64_t& streamId)
 {
   streamId = 1;
-  return OpenRecordedStreamImpl(recording);
+  return m_recordingManager && m_recordingManager->OpenRecordedStream(recording);
 }
-void IptvSimple::CloseRecordedStream(int64_t) { CloseRecordedStreamImpl(); }
-int IptvSimple::ReadRecordedStream(int64_t, unsigned char* buffer, unsigned int size) { return ReadRecordedStreamImpl(buffer, size); }
-int64_t IptvSimple::SeekRecordedStream(int64_t, int64_t position, int whence) { return SeekRecordedStreamImpl(position, whence); }
-int64_t IptvSimple::LengthRecordedStream(int64_t) { return LengthRecordedStreamImpl(); }
+void IptvSimple::CloseRecordedStream(int64_t) { if (m_recordingManager) m_recordingManager->CloseRecordedStream(); }
+int IptvSimple::ReadRecordedStream(int64_t, unsigned char* buffer, unsigned int size) { return m_recordingManager ? m_recordingManager->ReadRecordedStream(buffer, size) : -1; }
+int64_t IptvSimple::SeekRecordedStream(int64_t, int64_t position, int whence) { return m_recordingManager ? m_recordingManager->SeekRecordedStream(position, whence) : -1; }
+int64_t IptvSimple::LengthRecordedStream(int64_t) { return m_recordingManager ? m_recordingManager->LengthRecordedStream() : -1; }
 #else
-bool IptvSimple::OpenRecordedStream(const kodi::addon::PVRRecording& recording) { return OpenRecordedStreamImpl(recording); }
-void IptvSimple::CloseRecordedStream() { CloseRecordedStreamImpl(); }
-int IptvSimple::ReadRecordedStream(unsigned char* buffer, unsigned int size) { return ReadRecordedStreamImpl(buffer, size); }
-int64_t IptvSimple::SeekRecordedStream(int64_t position, int whence) { return SeekRecordedStreamImpl(position, whence); }
-int64_t IptvSimple::LengthRecordedStream() { return LengthRecordedStreamImpl(); }
+bool IptvSimple::OpenRecordedStream(const kodi::addon::PVRRecording& recording) { return m_recordingManager && m_recordingManager->OpenRecordedStream(recording); }
+void IptvSimple::CloseRecordedStream() { if (m_recordingManager) m_recordingManager->CloseRecordedStream(); }
+int IptvSimple::ReadRecordedStream(unsigned char* buffer, unsigned int size) { return m_recordingManager ? m_recordingManager->ReadRecordedStream(buffer, size) : -1; }
+int64_t IptvSimple::SeekRecordedStream(int64_t position, int whence) { return m_recordingManager ? m_recordingManager->SeekRecordedStream(position, whence) : -1; }
+int64_t IptvSimple::LengthRecordedStream() { return m_recordingManager ? m_recordingManager->LengthRecordedStream() : -1; }
 #endif
 
 /***************************************************************************

--- a/src/IptvSimple.h
+++ b/src/IptvSimple.h
@@ -25,7 +25,6 @@
 #include <thread>
 
 #include <kodi/addon-instance/PVR.h>
-#include <kodi/Filesystem.h>
 
 class ATTR_DLL_LOCAL IptvSimple : public iptvsimple::IConnectionListener
 {
@@ -149,14 +148,4 @@ private:
   // updates once the reload has completed. Caveat: the worker captures `this`
   // and, like the pre-existing detached operations, is not joined on teardown.
   void RunTimerOpAsync(std::function<void()> op);
-
-  // Recording byte-stream (used by Recordings section playback path)
-  bool OpenRecordedStreamImpl(const kodi::addon::PVRRecording& recording);
-  void CloseRecordedStreamImpl();
-  int ReadRecordedStreamImpl(unsigned char* buffer, unsigned int size);
-  int64_t SeekRecordedStreamImpl(int64_t position, int whence);
-  int64_t LengthRecordedStreamImpl();
-
-  kodi::vfs::CFile m_recordingStream;
-  bool m_recordingStreamOpen{false};
 };

--- a/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
+++ b/src/iptvsimple/jellyfin/JellyfinRecordingManager.cpp
@@ -1132,6 +1132,78 @@ PVR_ERROR JellyfinRecordingManager::GetRecordingLastPlayedPosition(const kodi::a
 }
 
 /***************************************************************************
+ * Recorded-stream byte path (Recordings window playback)
+ *
+ * Streams the raw recording file via /Videos/{id}/stream?static=true using
+ * kodi::vfs::CFile. Used by the PVR Recordings section, which opens recordings
+ * directly rather than via GetRecordingStreamProperties. Only one recording
+ * plays at a time and Kodi drives Open/Read/Seek/Close on a single playback
+ * thread, so this state is independent of the data model and not guarded by
+ * m_mutex.
+ **************************************************************************/
+
+bool JellyfinRecordingManager::OpenRecordedStream(const kodi::addon::PVRRecording& recording)
+{
+  CloseRecordedStream();
+
+  const std::string recordingId = recording.GetRecordingId();
+  if (!m_client)
+    return false;
+
+  const std::string streamUrl = m_client->GetBaseUrl()
+    + "/Videos/" + recordingId + "/stream?static=true&ApiKey="
+    + m_client->GetAccessToken();
+
+  Logger::Log(LEVEL_INFO, "%s - Opening recording stream for %s", __FUNCTION__, recordingId.c_str());
+
+  if (!m_recordingStream.OpenFile(streamUrl, ADDON_READ_NO_CACHE))
+  {
+    Logger::Log(LEVEL_ERROR, "%s - Failed to open recording stream: %s", __FUNCTION__, recordingId.c_str());
+    return false;
+  }
+
+  m_recordingStreamOpen = true;
+  Logger::Log(LEVEL_INFO, "%s - Recording stream open, length: %lld",
+              __FUNCTION__, static_cast<long long>(m_recordingStream.GetLength()));
+  return true;
+}
+
+void JellyfinRecordingManager::CloseRecordedStream()
+{
+  if (m_recordingStreamOpen)
+  {
+    Logger::Log(LEVEL_INFO, "%s - Closing recording stream", __FUNCTION__);
+    m_recordingStream.Close();
+    m_recordingStreamOpen = false;
+  }
+}
+
+int JellyfinRecordingManager::ReadRecordedStream(unsigned char* buffer, unsigned int size)
+{
+  if (!m_recordingStreamOpen)
+    return -1;
+
+  auto bytesRead = m_recordingStream.Read(buffer, size);
+  return static_cast<int>(bytesRead);
+}
+
+int64_t JellyfinRecordingManager::SeekRecordedStream(int64_t position, int whence)
+{
+  if (!m_recordingStreamOpen)
+    return -1;
+
+  return m_recordingStream.Seek(position, whence);
+}
+
+int64_t JellyfinRecordingManager::LengthRecordedStream()
+{
+  if (!m_recordingStreamOpen)
+    return -1;
+
+  return m_recordingStream.GetLength();
+}
+
+/***************************************************************************
  * Utilities
  **************************************************************************/
 

--- a/src/iptvsimple/jellyfin/JellyfinRecordingManager.h
+++ b/src/iptvsimple/jellyfin/JellyfinRecordingManager.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include <kodi/Filesystem.h>
 #include <kodi/addon-instance/pvr/Timers.h>
 #include <kodi/addon-instance/pvr/Recordings.h>
 
@@ -34,7 +35,7 @@ enum TimerTypeId
   TIMER_ONCE_MANUAL = 4              // Manual recording (channel + time, no EPG)
 };
 
-class JellyfinRecordingManager
+class ATTR_DLL_LOCAL JellyfinRecordingManager
 {
 public:
   JellyfinRecordingManager(std::shared_ptr<JellyfinClient> client,
@@ -60,6 +61,14 @@ public:
   PVR_ERROR SetRecordingPlayCount(const kodi::addon::PVRRecording& recording, int count);
   PVR_ERROR SetRecordingLastPlayedPosition(const kodi::addon::PVRRecording& recording, int lastplayedposition);
   PVR_ERROR GetRecordingLastPlayedPosition(const kodi::addon::PVRRecording& recording, int& position);
+
+  // Recorded-stream byte path (PVR Recordings window playback; raw static
+  // stream). One playback at a time, driven on Kodi's playback thread.
+  bool OpenRecordedStream(const kodi::addon::PVRRecording& recording);
+  void CloseRecordedStream();
+  int ReadRecordedStream(unsigned char* buffer, unsigned int size);
+  int64_t SeekRecordedStream(int64_t position, int whence);
+  int64_t LengthRecordedStream();
 
   void SetClient(std::shared_ptr<JellyfinClient> client) { m_client = client; }
   void SetChannels(iptvsimple::Channels* channels) { m_channels = channels; }
@@ -111,6 +120,11 @@ private:
   std::shared_ptr<JellyfinChannelLoader> m_channelLoader;
   std::shared_ptr<iptvsimple::InstanceSettings> m_settings;
   iptvsimple::Channels* m_channels{nullptr};
+
+  // Recorded-stream byte path state. Single playback at a time, accessed on
+  // Kodi's playback thread — independent of the data model, so not under m_mutex.
+  kodi::vfs::CFile m_recordingStream;
+  bool m_recordingStreamOpen{false};
 };
 
 } // namespace jellyfin


### PR DESCRIPTION
The PVR Recordings window opens recordings directly via OpenRecordedStream rather than GetRecordingStreamProperties, so the addon HTTP-streams the raw /Videos/{id}/stream?static=true file with kodi::vfs::CFile. That logic (and its m_recordingStream/m_recordingStreamOpen state) lived in IptvSimple even though it only needs the Jellyfin client.

Move it into JellyfinRecordingManager, which already owns recording state and the other playback path (GetRecordingStreamProperties), co-locating both. The IptvSimple PVR overrides now just adapt the v21/v22 signatures and delegate to the manager. Behaviour is unchanged.

Also: mark JellyfinRecordingManager ATTR_DLL_LOCAL (matching IptvSimple and the addon's other internal classes) so its hidden-visibility CFile member doesn't trip -Wattributes; drop the now-unused <kodi/Filesystem.h> include from IptvSimple.h (still available transitively via the manager header).