### PR TITLE
Settings tidy-up

### DIFF
--- a/pvr.kofin/addon.xml.in
+++ b/pvr.kofin/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.kofin"
-  version="0.10.0"
+  version="0.10.1"
   name="Kofin PVR for Jellyfin"
   provider-name="Kontell">
   <requires>@ADDON_DEPENDS@

--- a/pvr.kofin/changelog.txt
+++ b/pvr.kofin/changelog.txt
@@ -1,3 +1,7 @@
+v0.10.1
+- Decouple catchup from the reference playlist setting
+- Tidy up settings descriptions
+
 v0.10.0
 - Starting a recording no longer freezes the Kodi UI for several seconds: the timer is now created on a background thread instead of blocking the interface while the Jellyfin requests complete
 - Recordings, home-screen widgets, and the EPG "Play recording" menu entry now refresh as soon as a recording starts or stops, instead of waiting up to 60 seconds for the next background poll

--- a/pvr.kofin/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.kofin/resources/language/resource.language.en_gb/strings.po
@@ -187,7 +187,7 @@ msgid "In-progress recording InputStream"
 msgstr ""
 
 msgctxt "#30669"
-msgid "The InputStream to use for in-progress recording playback. Use FFmpeg (Kodi internal) if Adaptive causes crashes on your device."
+msgid "The InputStream to use for in-progress recording playback. Adaptive can skip forward through an in-progress recording. FFmpeg cannot skip ahead but may be more robust."
 msgstr ""
 
 #: Advanced category
@@ -330,7 +330,7 @@ msgid "Enable catchup (IPTV)"
 msgstr ""
 
 msgctxt "#30732"
-msgid "Enable catchup/archive TV if supported by your provider. Only works with direct play, so force remuxing must be turned off and bitrate set unlimited. Requires a reference M3U file that matches your Jellyfin channel names and contains catchup tags which are omitted by Jellyfin."
+msgid "Enable catchup/archive TV if supported by your provider. Only works with direct play, so force remuxing must be turned off and bitrate set unlimited. Requires a reference M3U file (configured in the Advanced section) that matches your Jellyfin channel names and contains catchup tags which are omitted by Jellyfin."
 msgstr ""
 
 msgctxt "#30733"
@@ -549,7 +549,7 @@ msgid "Maximum audio channels"
 msgstr ""
 
 msgctxt "#30792"
-msgid "Maximum number of audio channels allowed when transcoding. Streams with more channels will be downmixed."
+msgid "Maximum number of audio channels allowed when transcoding. Streams with more channels will be downmixed. No effect on direct playback."
 msgstr ""
 
 msgctxt "#30793"

--- a/pvr.kofin/resources/settings.xml
+++ b/pvr.kofin/resources/settings.xml
@@ -434,11 +434,6 @@
         <setting id="catchupEnabled" type="boolean" label="30731" help="30732">
           <level>0</level>
           <default>false</default>
-          <dependencies>
-            <dependency type="enable">
-              <condition operator="is" setting="referencePlaylistEnabled">true</condition>
-            </dependency>
-          </dependencies>
           <control type="toggle" />
         </setting>
         <setting id="catchupQueryFormat" type="string" label="30739" help="30740">


### PR DESCRIPTION
- Decouple catchup from referencePlaylistEnabled (remove enable dependency)
- maxAudioChannels help: note no effect on direct playback
- In-progress InputStream help: adaptive seeks forward, FFmpeg more robust
- Catchup help points to the reference playlist in the Advanced section